### PR TITLE
docs: Complete documentation suite for ABC Emergency integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,167 +1,113 @@
-# ABC Emergency for Home Assistant
+<p align="center">
+  <img src="https://raw.githubusercontent.com/troykelly/homeassistant-abcemergency/main/custom_components/abcemergency/images/icon%402x.png" alt="ABC Emergency Logo" width="128" height="128">
+</p>
 
-[![GitHub Release](https://img.shields.io/github/release/troykelly/homeassistant-abcemergency.svg?style=flat-square)](https://github.com/troykelly/homeassistant-abcemergency/releases)
-[![GitHub Activity](https://img.shields.io/github/commit-activity/y/troykelly/homeassistant-abcemergency.svg?style=flat-square)](https://github.com/troykelly/homeassistant-abcemergency/commits/main)
-[![License](https://img.shields.io/github/license/troykelly/homeassistant-abcemergency.svg?style=flat-square)](LICENSE)
-[![hacs](https://img.shields.io/badge/HACS-Custom-orange.svg?style=flat-square)](https://hacs.xyz)
+<h1 align="center">ABC Emergency for Home Assistant</h1>
 
-A Home Assistant custom integration for [ABC Emergency](https://www.abc.net.au/emergency) - Australia's emergency information service from the Australian Broadcasting Corporation.
+<p align="center">
+  <strong>Real-time Australian emergency alerts in your smart home</strong>
+</p>
 
-## Features
+<p align="center">
+  <a href="https://github.com/troykelly/homeassistant-abcemergency/releases"><img src="https://img.shields.io/github/release/troykelly/homeassistant-abcemergency.svg?style=flat-square" alt="GitHub Release"></a>
+  <a href="https://github.com/troykelly/homeassistant-abcemergency/commits/main"><img src="https://img.shields.io/github/commit-activity/y/troykelly/homeassistant-abcemergency.svg?style=flat-square" alt="GitHub Activity"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/troykelly/homeassistant-abcemergency.svg?style=flat-square" alt="License"></a>
+  <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=flat-square" alt="HACS"></a>
+</p>
 
-- Real-time emergency incident data for all Australian states and territories
-- Three monitoring modes:
-  - **State Mode** - Monitor all incidents in a state/territory
-  - **Zone Mode** - Monitor incidents near a fixed location with configurable radii
-  - **Person Mode** - Monitor incidents near a person's dynamic location
-- Support for the Australian Warning System alert levels (Advice, Watch and Act, Emergency Warning)
-- Per-incident-type radius configuration for location-based monitoring
-- Sensors for incident counts, nearest incident, and alert levels
-- Binary sensors for active alerts at each warning level
-- Geo-location entities for mapping incidents
+<p align="center">
+  <a href="#-quick-start">Quick Start</a> &bull;
+  <a href="docs/getting-started.md">Installation Guide</a> &bull;
+  <a href="docs/automations.md">Automations</a> &bull;
+  <a href="docs/troubleshooting.md">Troubleshooting</a>
+</p>
 
-### Supported Incident Types
+---
+
+> **Important:** This integration is **NOT** authorised, endorsed, or affiliated with the Australian Broadcasting Corporation (ABC). This is an independent community project that uses publicly available data from [ABC Emergency](https://www.abc.net.au/emergency) to help Australians stay informed during emergencies.
+
+---
+
+## Why ABC Emergency for Home Assistant?
+
+When bushfires, floods, or storms threaten your home, every minute counts. This integration brings Australia's most comprehensive emergency information service directly into your smart home, enabling:
+
+- **Instant mobile alerts** when emergencies occur near your home
+- **Tiered notifications** based on Australian Warning System levels
+- **Family safety monitoring** - track alerts near loved ones as they travel
+- **Smart home automation** - trigger lights, sirens, or announcements during emergencies
+- **Multi-location awareness** - monitor your home, workplace, and holiday house simultaneously
+
+---
+
+## Key Features
+
+### Three Monitoring Modes
+
+| Mode | Best For | How It Works |
+|------|----------|--------------|
+| **State Mode** | Overview of all emergencies | Monitors every incident in a state/territory |
+| **Zone Mode** | Protecting fixed locations | Alerts within configurable radius of your home, office, etc. |
+| **Person Mode** | Family safety | Follows a person's location as they move |
+
+### Australian Warning System Integration
+
+This integration uses the official [Australian Warning System](https://www.australianwarningsystem.com.au/) levels:
+
+| Level | Color | Meaning | Your Action |
+|-------|-------|---------|-------------|
+| **Emergency Warning** | Red | You may be in danger | Act immediately to protect yourself |
+| **Watch and Act** | Orange | Conditions changing | Take action now to prepare |
+| **Advice** | Yellow | Incident occurring | Stay informed and monitor conditions |
+
+### Comprehensive Incident Coverage
 
 - Bushfires and grass fires
-- Floods
-- Storms and severe weather
+- Floods and storms
+- Severe weather and cyclones
 - Earthquakes
 - Extreme heat and heatwaves
 - Structure fires
 - And more...
 
-### Australian Warning System
+### Smart Alerting
 
-| Level | Meaning |
-|-------|---------|
-| **Advice** (Yellow) | An incident has started. No immediate danger. Stay informed. |
-| **Watch and Act** (Orange) | Heightened threat. Conditions changing. Take action now. |
-| **Emergency Warning** (Red) | Highest level. You may be in danger. Act immediately. |
+- **Per-incident-type radius** - Bushfires alert at 50km, structure fires at 10km
+- **Nearest incident tracking** - Know exactly how far away the closest threat is
+- **Binary sensors** - Simple on/off triggers for each warning level
+- **Geo-location entities** - See all incidents on your Home Assistant map
 
-## Installation
+---
 
-### HACS (Recommended)
+## Quick Start
+
+### 1. Install via HACS
 
 1. Open HACS in Home Assistant
-2. Click the three dots in the top right corner
-3. Select "Custom repositories"
-4. Add `https://github.com/troykelly/homeassistant-abcemergency` with category "Integration"
-5. Click "Install"
-6. Restart Home Assistant
+2. Click the three dots menu → **Custom repositories**
+3. Add: `https://github.com/troykelly/homeassistant-abcemergency`
+4. Select category: **Integration**
+5. Click **Install**
+6. **Restart Home Assistant**
 
-### Manual Installation
+### 2. Add the Integration
 
-1. Download the latest release from [GitHub](https://github.com/troykelly/homeassistant-abcemergency/releases)
-2. Extract and copy the `custom_components/abcemergency` folder to your Home Assistant `custom_components` directory
-3. Restart Home Assistant
-
-## Configuration
-
-1. Go to **Settings** > **Devices & Services**
+1. Go to **Settings** → **Devices & Services**
 2. Click **Add Integration**
-3. Search for "ABC Emergency"
-4. Select your monitoring mode:
+3. Search for **ABC Emergency**
+4. Follow the setup wizard
 
-### State Mode
-
-Monitor all incidents in an Australian state or territory.
-
-1. Select "Monitor a State/Territory"
-2. Choose the state (NSW, VIC, QLD, SA, WA, TAS, NT, or ACT)
-3. Done! All incidents in that state will be tracked.
-
-**Use case:** Get a complete overview of emergency activity in your state.
-
-### Zone Mode
-
-Monitor incidents near a fixed location (your home, office, etc.).
-
-1. Select "Monitor a fixed location (zone)"
-2. Enter a name for the zone (e.g., "Home", "Office")
-3. Select the location on the map
-4. Configure alert radii for each incident type
-
-**Use case:** Get alerts for incidents that could affect a specific location.
-
-### Person Mode
-
-Monitor incidents near a person's dynamic location as they move.
-
-1. Select "Monitor a person's location"
-2. Choose a person entity from your Home Assistant
-3. Configure alert radii for each incident type
-
-**Use case:** Track emergency situations around family members as they travel.
-
-### Per-Incident-Type Radius (Zone/Person modes)
-
-Different incident types have different default alert radii:
-
-| Incident Type | Default Radius |
-|---------------|----------------|
-| Bushfire | 50 km |
-| Earthquake | 100 km |
-| Storm | 75 km |
-| Flood | 30 km |
-| Structure Fire | 10 km |
-| Extreme Heat | 100 km |
-| Other | 25 km |
-
-Radii can be adjusted in the options flow after setup.
-
-## Multiple Instances
-
-You can add multiple instances of the integration to monitor different areas:
-
-- One state instance for NSW + one for VIC
-- A zone instance for your home + a zone for your workplace
-- Person instances for each family member
-
-Each instance creates its own set of entities.
-
-## Entities
-
-Each instance creates a device with the following entities:
-
-### Sensors (All Modes)
-
-| Sensor | Description |
-|--------|-------------|
-| `incidents_total` | Total active incidents |
-| `highest_alert_level` | Highest warning level |
-| `bushfires` | Active bushfire count |
-| `floods` | Active flood count |
-| `storms` | Active storm count |
-
-### Additional Sensors (Zone/Person Modes Only)
-
-| Sensor | Description |
-|--------|-------------|
-| `incidents_nearby` | Incidents within configured radii |
-| `nearest_incident` | Distance to nearest incident (km) |
-
-### Binary Sensors (All Modes)
-
-| Sensor | Description |
-|--------|-------------|
-| `active_alert` | Any alert in monitored area |
-| `emergency_warning` | Emergency Warning (red) active |
-| `watch_and_act` | Watch and Act (orange) or higher |
-| `advice` | Advice (yellow) or higher |
-
-## Automation Examples
-
-### Emergency Warning Notification
+### 3. Create Your First Automation
 
 ```yaml
 automation:
-  - alias: "ABC Emergency Warning Alert"
+  - alias: "Emergency Warning Alert"
     trigger:
       - platform: state
         entity_id: binary_sensor.abc_emergency_home_emergency_warning
         to: "on"
     action:
-      - service: notify.mobile_app
+      - service: notify.mobile_app_your_phone
         data:
           title: "EMERGENCY WARNING"
           message: >
@@ -172,27 +118,84 @@ automation:
             channel: emergency
 ```
 
-### Nearby Bushfire Alert
+**That's it!** You'll now receive critical alerts when emergencies threaten your home.
+
+---
+
+## Documentation
+
+| Guide | Description |
+|-------|-------------|
+| [Getting Started](docs/getting-started.md) | Detailed installation and first-time setup |
+| [Configuration](docs/configuration.md) | All configuration options explained |
+| [Entities Reference](docs/entities.md) | Complete list of sensors and their attributes |
+| [Automations](docs/automations.md) | Ready-to-use automation examples |
+| [Notifications](docs/notifications.md) | Mobile alerts, critical notifications, TTS |
+| [Scripts](docs/scripts.md) | Emergency briefings, evacuation checklists |
+| [Troubleshooting](docs/troubleshooting.md) | Common issues and solutions |
+| [Advanced Usage](docs/advanced.md) | Templates, Node-RED, AppDaemon |
+
+---
+
+## Example Automations
+
+### Tiered Notifications by Warning Level
 
 ```yaml
 automation:
-  - alias: "Bushfire Within 20km"
+  # Advice level - informational notification
+  - alias: "ABC Emergency - Advice Notification"
     trigger:
-      - platform: numeric_state
-        entity_id: sensor.abc_emergency_home_nearest_incident
-        below: 20
+      - platform: state
+        entity_id: binary_sensor.abc_emergency_home_advice
+        to: "on"
     condition:
       - condition: state
-        entity_id: sensor.abc_emergency_home_nearest_incident
-        attribute: event_type
-        state: "Bushfire"
+        entity_id: binary_sensor.abc_emergency_home_watch_and_act
+        state: "off"
     action:
-      - service: notify.all_devices
+      - service: notify.mobile_app_your_phone
         data:
-          message: "Bushfire detected {{ states('sensor.abc_emergency_home_nearest_incident') }}km away!"
+          title: "Emergency Advice"
+          message: >
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+            ({{ states('sensor.abc_emergency_home_nearest_incident') }}km away)
+
+  # Watch and Act - more urgent
+  - alias: "ABC Emergency - Watch and Act"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.abc_emergency_home_watch_and_act
+        to: "on"
+    action:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "WATCH AND ACT"
+          message: >
+            Take action now! {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+            is {{ states('sensor.abc_emergency_home_nearest_incident') }}km away
+          data:
+            priority: high
+
+  # Emergency Warning - critical
+  - alias: "ABC Emergency - Emergency Warning"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.abc_emergency_home_emergency_warning
+        to: "on"
+    action:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "EMERGENCY WARNING"
+          message: >
+            Act immediately! {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+            is {{ states('sensor.abc_emergency_home_nearest_incident') }}km away
+          data:
+            priority: critical
+            channel: alarm
 ```
 
-### Alert When Person Enters Emergency Zone
+### Family Member Safety Alert
 
 ```yaml
 automation:
@@ -202,33 +205,91 @@ automation:
         entity_id: binary_sensor.abc_emergency_dad_active_alert
         to: "on"
     action:
-      - service: notify.mobile_app_mum
+      - service: notify.family_group
         data:
           title: "Emergency Near Dad"
           message: >
             There's an active emergency near Dad's location.
             Distance: {{ states('sensor.abc_emergency_dad_nearest_incident') }}km
+            Type: {{ state_attr('sensor.abc_emergency_dad_nearest_incident', 'event_type') }}
 ```
 
-## Migration from Previous Versions
+See [Automations Guide](docs/automations.md) for more examples including TTS announcements, smart light alerts, and quiet hours handling.
 
-If upgrading from v1 or v2, your existing configuration will be automatically migrated:
+---
 
-- **From v1:** Single state config becomes a State mode instance
-- **From v2:** Multi-state config becomes a State mode instance for the first state
+## Entities Created
 
-After migration, you can add additional instances as needed.
+Each instance creates a device with these entities:
 
-## Data Source
+### Sensors
 
-This integration uses data from [ABC Emergency](https://www.abc.net.au/emergency), which aggregates emergency information from state and territory emergency services across Australia.
+| Entity | Description |
+|--------|-------------|
+| `sensor.abc_emergency_*_incidents_total` | Total active incidents |
+| `sensor.abc_emergency_*_incidents_nearby` | Incidents within your configured radii |
+| `sensor.abc_emergency_*_nearest_incident` | Distance (km) to nearest incident |
+| `sensor.abc_emergency_*_highest_alert_level` | Highest warning level active |
+| `sensor.abc_emergency_*_bushfires` | Active bushfire count |
+| `sensor.abc_emergency_*_floods` | Active flood count |
+| `sensor.abc_emergency_*_storms` | Active storm count |
 
-**Note:** This is an unofficial integration and is not affiliated with or endorsed by the Australian Broadcasting Corporation.
+### Binary Sensors
+
+| Entity | Meaning |
+|--------|---------|
+| `binary_sensor.abc_emergency_*_active_alert` | Any alert active |
+| `binary_sensor.abc_emergency_*_emergency_warning` | Red level (highest) |
+| `binary_sensor.abc_emergency_*_watch_and_act` | Orange level or higher |
+| `binary_sensor.abc_emergency_*_advice` | Yellow level or higher |
+
+---
 
 ## Contributing
 
-Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+This project follows:
+- Test-Driven Development (TDD)
+- Issue-Driven Development (all changes require a linked GitHub issue)
+- Strict type safety (no `Any` types)
+
+---
+
+## The Story Behind This Integration
+
+This integration was created in early December 2025 when bushfires broke out near a friend's house in Woy Woy, NSW. We needed a way to easily add alerting to our chosen family group so everyone could stay informed and safe.
+
+What started as a quick hack to help friends became a full-featured integration that we hope helps other Australians protect their homes and loved ones.
+
+---
+
+## Acknowledgment of Country
+
+This code was written on the land of the Gadigal and Wangal peoples of the Eora Nation. We pay our respects to Elders past, present, and emerging, and acknowledge that sovereignty was never ceded.
+
+In the spirit of this integration's purpose - helping communities stay safe during emergencies - we acknowledge the tens of thousands of years of land management by First Nations peoples, including the use of cultural burning practices that helped maintain the health of Country.
+
+---
+
+## Data Source & Disclaimer
+
+This integration uses publicly available data from [ABC Emergency](https://www.abc.net.au/emergency), which aggregates emergency information from state and territory emergency services across Australia.
+
+**This is NOT an official ABC product.** The ABC Emergency website states:
+
+> The information displayed on this page is assembled from multiple data sources and may not reflect the most up-to-date information available. For emergency information, contact your local emergency services.
+
+**Always follow official emergency service instructions.** This integration is a convenience tool and should not be your only source of emergency information. In a life-threatening emergency, call **000**.
+
+---
 
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+---
+
+<p align="center">
+  <sub>Made with care for the Australian community</sub>
+</p>

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,679 @@
+# Advanced Usage Guide
+
+Power user features, template sensors, and third-party integrations for ABC Emergency.
+
+---
+
+## Template Sensors
+
+Create custom sensors derived from ABC Emergency data.
+
+### Bushfire Risk Level Sensor
+
+Combine multiple factors into a risk level:
+
+```yaml
+template:
+  - sensor:
+      - name: "Bushfire Risk Level"
+        unique_id: bushfire_risk_level
+        state: >
+          {% set bushfires = states('sensor.abc_emergency_home_bushfires') | int(0) %}
+          {% set nearest = states('sensor.abc_emergency_home_nearest_incident') | float(999) %}
+          {% set is_bushfire = state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') == 'Bushfire' %}
+          {% set level = states('sensor.abc_emergency_home_highest_alert_level') %}
+
+          {% if level == 'Emergency' and is_bushfire and nearest < 20 %}
+            Extreme
+          {% elif level in ['Emergency', 'Watch and Act'] and is_bushfire and nearest < 50 %}
+            Very High
+          {% elif bushfires > 0 and nearest < 75 %}
+            High
+          {% elif bushfires > 0 %}
+            Moderate
+          {% else %}
+            Low
+          {% endif %}
+        icon: >
+          {% if is_state('sensor.bushfire_risk_level', 'Extreme') %}
+            mdi:fire-alert
+          {% elif is_state('sensor.bushfire_risk_level', 'Very High') %}
+            mdi:fire
+          {% elif is_state('sensor.bushfire_risk_level', 'High') %}
+            mdi:fire
+          {% else %}
+            mdi:fire-off
+          {% endif %}
+```
+
+### Nearest Incident Summary Sensor
+
+A single sensor with formatted summary:
+
+```yaml
+template:
+  - sensor:
+      - name: "Emergency Summary"
+        unique_id: emergency_summary
+        state: >
+          {% if is_state('binary_sensor.abc_emergency_home_active_alert', 'on') %}
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }}
+            {{ states('sensor.abc_emergency_home_nearest_incident') }}km
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'direction') }}
+          {% else %}
+            No active alerts
+          {% endif %}
+        attributes:
+          headline: >
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+          alert_level: >
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'alert_level') }}
+          url: "https://www.abc.net.au/emergency"
+```
+
+### Family Safety Status Sensor
+
+Aggregate family member safety:
+
+```yaml
+template:
+  - sensor:
+      - name: "Family Emergency Status"
+        unique_id: family_emergency_status
+        state: >
+          {% set alerts = namespace(count=0) %}
+          {% if is_state('binary_sensor.abc_emergency_mum_active_alert', 'on') %}
+            {% set alerts.count = alerts.count + 1 %}
+          {% endif %}
+          {% if is_state('binary_sensor.abc_emergency_dad_active_alert', 'on') %}
+            {% set alerts.count = alerts.count + 1 %}
+          {% endif %}
+          {% if is_state('binary_sensor.abc_emergency_child_active_alert', 'on') %}
+            {% set alerts.count = alerts.count + 1 %}
+          {% endif %}
+
+          {% if alerts.count == 0 %}
+            All Clear
+          {% elif alerts.count == 1 %}
+            1 Member in Alert Zone
+          {% else %}
+            {{ alerts.count }} Members in Alert Zones
+          {% endif %}
+        attributes:
+          mum_status: >
+            {{ 'Alert' if is_state('binary_sensor.abc_emergency_mum_active_alert', 'on') else 'Clear' }}
+          dad_status: >
+            {{ 'Alert' if is_state('binary_sensor.abc_emergency_dad_active_alert', 'on') else 'Clear' }}
+          child_status: >
+            {{ 'Alert' if is_state('binary_sensor.abc_emergency_child_active_alert', 'on') else 'Clear' }}
+```
+
+---
+
+## Custom Lovelace Cards
+
+### Emergency Status Card
+
+```yaml
+type: vertical-stack
+cards:
+  - type: markdown
+    content: |
+      # Emergency Status
+      **Highest Alert:** {{ states('sensor.abc_emergency_home_highest_alert_level') }}
+
+      {% if is_state('binary_sensor.abc_emergency_home_active_alert', 'on') %}
+      ## ⚠️ Active Alert
+
+      **{{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}**
+
+      | | |
+      |---|---|
+      | Type | {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }} |
+      | Distance | {{ states('sensor.abc_emergency_home_nearest_incident') }} km |
+      | Direction | {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'direction') }} |
+      | Level | {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'alert_level') }} |
+      {% else %}
+      ✅ No active emergencies near your location.
+      {% endif %}
+
+  - type: entities
+    entities:
+      - entity: sensor.abc_emergency_home_incidents_total
+      - entity: sensor.abc_emergency_home_incidents_nearby
+      - entity: sensor.abc_emergency_home_bushfires
+      - entity: sensor.abc_emergency_home_floods
+      - entity: sensor.abc_emergency_home_storms
+```
+
+### Conditional Alert Banner
+
+```yaml
+type: conditional
+conditions:
+  - entity: binary_sensor.abc_emergency_home_emergency_warning
+    state: "on"
+card:
+  type: markdown
+  content: |
+    # 🚨 EMERGENCY WARNING 🚨
+
+    **{{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}**
+    is **{{ states('sensor.abc_emergency_home_nearest_incident') }}km** away!
+
+    **ACT IMMEDIATELY**
+  style: |
+    ha-card {
+      background-color: #d31717;
+      color: white;
+    }
+```
+
+### Warning Level Gauge
+
+Using a gauge to show proximity:
+
+```yaml
+type: gauge
+entity: sensor.abc_emergency_home_nearest_incident
+name: Nearest Emergency
+min: 0
+max: 100
+severity:
+  green: 50
+  yellow: 20
+  red: 10
+needle: true
+```
+
+---
+
+## Node-RED Integration
+
+### Basic Alert Flow
+
+```json
+[
+    {
+        "id": "abc_emergency_trigger",
+        "type": "server-state-changed",
+        "name": "Emergency Warning",
+        "server": "",
+        "entityid": "binary_sensor.abc_emergency_home_emergency_warning",
+        "entityidtype": "exact",
+        "outputonlyonchange": true,
+        "outputproperties": [
+            {
+                "property": "payload",
+                "propertyType": "msg",
+                "value": "",
+                "valueType": "entityState"
+            }
+        ],
+        "x": 150,
+        "y": 100,
+        "wires": [["filter_on"]]
+    },
+    {
+        "id": "filter_on",
+        "type": "switch",
+        "name": "Filter On",
+        "property": "payload",
+        "rules": [
+            {"t": "eq", "v": "on", "vt": "str"}
+        ],
+        "x": 350,
+        "y": 100,
+        "wires": [["get_details"]]
+    },
+    {
+        "id": "get_details",
+        "type": "api-current-state",
+        "name": "Get Incident Details",
+        "server": "",
+        "outputs": 1,
+        "entityid": "sensor.abc_emergency_home_nearest_incident",
+        "x": 550,
+        "y": 100,
+        "wires": [["format_message"]]
+    },
+    {
+        "id": "format_message",
+        "type": "function",
+        "name": "Format Message",
+        "func": "msg.payload = {\n    title: 'EMERGENCY WARNING',\n    message: msg.data.attributes.headline + ' is ' + msg.data.state + 'km away!',\n    data: {\n        priority: 'critical'\n    }\n};\nreturn msg;",
+        "x": 750,
+        "y": 100,
+        "wires": [["notify"]]
+    },
+    {
+        "id": "notify",
+        "type": "api-call-service",
+        "name": "Send Notification",
+        "server": "",
+        "service": "notify.mobile_app_phone",
+        "x": 950,
+        "y": 100,
+        "wires": [[]]
+    }
+]
+```
+
+### Distance-Based Escalation Flow
+
+```json
+[
+    {
+        "id": "distance_monitor",
+        "type": "server-state-changed",
+        "name": "Distance Changed",
+        "entityid": "sensor.abc_emergency_home_nearest_incident",
+        "x": 150,
+        "y": 200,
+        "wires": [["distance_check"]]
+    },
+    {
+        "id": "distance_check",
+        "type": "switch",
+        "name": "Check Distance",
+        "property": "payload",
+        "rules": [
+            {"t": "lt", "v": "5", "vt": "num"},
+            {"t": "lt", "v": "15", "vt": "num"},
+            {"t": "lt", "v": "30", "vt": "num"}
+        ],
+        "x": 350,
+        "y": 200,
+        "wires": [["critical"], ["urgent"], ["warning"]]
+    }
+]
+```
+
+---
+
+## AppDaemon Integration
+
+### Emergency Monitor App
+
+Create `apps/emergency_monitor.py`:
+
+```python
+import appdaemon.plugins.hass.hassapi as hass
+from datetime import datetime
+
+
+class EmergencyMonitor(hass.Hass):
+    """Monitor ABC Emergency and take actions."""
+
+    def initialize(self):
+        """Initialize the app."""
+        self.log("Emergency Monitor starting")
+
+        # Monitor emergency warning sensor
+        self.listen_state(
+            self.emergency_warning_changed,
+            "binary_sensor.abc_emergency_home_emergency_warning",
+        )
+
+        # Monitor distance changes
+        self.listen_state(
+            self.distance_changed,
+            "sensor.abc_emergency_home_nearest_incident",
+        )
+
+        # Track last notification time to avoid spam
+        self.last_notification = {}
+
+    def emergency_warning_changed(self, entity, attribute, old, new, kwargs):
+        """Handle emergency warning state changes."""
+        if new == "on":
+            self.handle_emergency_warning()
+        elif new == "off" and old == "on":
+            self.handle_all_clear()
+
+    def handle_emergency_warning(self):
+        """React to emergency warning."""
+        nearest = self.get_state("sensor.abc_emergency_home_nearest_incident")
+        headline = self.get_state(
+            "sensor.abc_emergency_home_nearest_incident",
+            attribute="headline"
+        )
+        event_type = self.get_state(
+            "sensor.abc_emergency_home_nearest_incident",
+            attribute="event_type"
+        )
+
+        # Turn on emergency lights
+        self.turn_on("light.living_room", brightness=255, color_name="red")
+
+        # Flash lights
+        for _ in range(3):
+            self.turn_off("light.front_porch")
+            self.run_in(lambda *args: self.turn_on("light.front_porch", color_name="red"), 0.5)
+            self.run_in(lambda *args: self.turn_off("light.front_porch"), 1.0)
+
+        # Send critical notification
+        self.call_service(
+            "notify/mobile_app_phone",
+            title="EMERGENCY WARNING",
+            message=f"{event_type}: {headline} is {nearest}km away!",
+            data={"priority": "critical"},
+        )
+
+        # Announce on speakers
+        self.call_service(
+            "tts/google_translate_say",
+            entity_id="media_player.living_room_speaker",
+            message=f"Emergency Warning! {event_type} is {nearest} kilometres away. Take action immediately!",
+        )
+
+    def handle_all_clear(self):
+        """Handle when emergency warning clears."""
+        self.turn_on("light.living_room", color_temp_kelvin=3000, brightness=128)
+
+        self.call_service(
+            "notify/mobile_app_phone",
+            title="All Clear",
+            message="Emergency warning has been cleared. Stay vigilant.",
+        )
+
+    def distance_changed(self, entity, attribute, old, new, kwargs):
+        """Handle distance changes for escalating alerts."""
+        try:
+            old_dist = float(old) if old not in ["unknown", "unavailable", None] else 999
+            new_dist = float(new) if new not in ["unknown", "unavailable", None] else 999
+        except (ValueError, TypeError):
+            return
+
+        # Only alert if getting closer
+        if new_dist >= old_dist:
+            return
+
+        # Rate limit notifications
+        now = datetime.now()
+        threshold = None
+
+        if new_dist < 5 and old_dist >= 5:
+            threshold = "5km"
+        elif new_dist < 15 and old_dist >= 15:
+            threshold = "15km"
+        elif new_dist < 30 and old_dist >= 30:
+            threshold = "30km"
+
+        if threshold:
+            last = self.last_notification.get(threshold)
+            if last and (now - last).total_seconds() < 1800:  # 30 min cooldown
+                return
+
+            self.last_notification[threshold] = now
+            self.send_distance_alert(new_dist, threshold)
+
+    def send_distance_alert(self, distance, threshold):
+        """Send distance-based alert."""
+        headline = self.get_state(
+            "sensor.abc_emergency_home_nearest_incident",
+            attribute="headline"
+        )
+
+        priority = "critical" if threshold == "5km" else "high"
+
+        self.call_service(
+            "notify/mobile_app_phone",
+            title=f"Emergency Now Within {threshold}",
+            message=f"{headline} is {distance:.1f}km away and approaching!",
+            data={"priority": priority},
+        )
+```
+
+Configure in `apps/apps.yaml`:
+
+```yaml
+emergency_monitor:
+  module: emergency_monitor
+  class: EmergencyMonitor
+```
+
+---
+
+## REST API Access
+
+Access ABC Emergency data via Home Assistant's REST API.
+
+### Get Sensor State
+
+```bash
+curl -X GET \
+  -H "Authorization: Bearer YOUR_LONG_LIVED_TOKEN" \
+  -H "Content-Type: application/json" \
+  http://your-ha-instance:8123/api/states/sensor.abc_emergency_home_nearest_incident
+```
+
+### Trigger Update
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer YOUR_LONG_LIVED_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"entity_id": "sensor.abc_emergency_home_incidents_total"}' \
+  http://your-ha-instance:8123/api/services/homeassistant/update_entity
+```
+
+---
+
+## WebSocket Integration
+
+### Subscribe to State Changes
+
+```javascript
+const socket = new WebSocket('ws://your-ha-instance:8123/api/websocket');
+
+socket.onopen = () => {
+  // Authenticate
+  socket.send(JSON.stringify({
+    type: 'auth',
+    access_token: 'YOUR_LONG_LIVED_TOKEN'
+  }));
+};
+
+socket.onmessage = (event) => {
+  const data = JSON.parse(event.data);
+
+  if (data.type === 'auth_ok') {
+    // Subscribe to emergency sensor
+    socket.send(JSON.stringify({
+      id: 1,
+      type: 'subscribe_events',
+      event_type: 'state_changed'
+    }));
+  }
+
+  if (data.type === 'event' && data.event.data.entity_id.startsWith('abc_emergency')) {
+    console.log('Emergency update:', data.event.data);
+  }
+};
+```
+
+---
+
+## Database Queries
+
+Query ABC Emergency history from the Home Assistant database.
+
+### SQLite Query Example
+
+```sql
+-- Get all emergency warning activations
+SELECT
+  datetime(last_changed, 'localtime') as time,
+  state
+FROM states
+WHERE entity_id = 'binary_sensor.abc_emergency_home_emergency_warning'
+  AND state IN ('on', 'off')
+ORDER BY last_changed DESC
+LIMIT 50;
+
+-- Get nearest incident distance over time
+SELECT
+  datetime(last_changed, 'localtime') as time,
+  state as distance_km,
+  json_extract(attributes, '$.headline') as headline
+FROM states
+WHERE entity_id = 'sensor.abc_emergency_home_nearest_incident'
+  AND state NOT IN ('unknown', 'unavailable')
+ORDER BY last_changed DESC
+LIMIT 100;
+```
+
+---
+
+## Integration with External Services
+
+### IFTTT Integration
+
+Create applets triggered by ABC Emergency:
+
+1. **Trigger:** Webhook (receive from HA)
+2. **Action:** SMS, email, smart home action
+
+In Home Assistant:
+
+```yaml
+automation:
+  - alias: "IFTTT Emergency Alert"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.abc_emergency_home_emergency_warning
+        to: "on"
+    action:
+      - service: ifttt.trigger
+        data:
+          event: emergency_warning
+          value1: "{{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}"
+          value2: "{{ states('sensor.abc_emergency_home_nearest_incident') }}"
+```
+
+### Pushover with Sounds
+
+```yaml
+automation:
+  - alias: "Pushover Emergency"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.abc_emergency_home_emergency_warning
+        to: "on"
+    action:
+      - service: notify.pushover
+        data:
+          title: "EMERGENCY"
+          message: "{{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}"
+          data:
+            sound: siren
+            priority: 2
+            retry: 30
+            expire: 3600
+```
+
+---
+
+## Statistics and Long-term Storage
+
+### InfluxDB Export
+
+Configure for long-term analytics:
+
+```yaml
+influxdb:
+  host: localhost
+  include:
+    entities:
+      - sensor.abc_emergency_home_incidents_total
+      - sensor.abc_emergency_home_nearest_incident
+      - sensor.abc_emergency_home_bushfires
+```
+
+### Grafana Dashboard
+
+Query examples for Grafana:
+
+```sql
+-- Incident count over time
+SELECT mean("value")
+FROM "sensor.abc_emergency_home_incidents_total"
+WHERE $timeFilter
+GROUP BY time($interval)
+
+-- Emergency warning activations
+SELECT count("value")
+FROM "binary_sensor.abc_emergency_home_emergency_warning"
+WHERE "value" = 'on' AND $timeFilter
+GROUP BY time(1d)
+```
+
+---
+
+## Performance Optimization
+
+### Exclude from Recorder
+
+Reduce database size:
+
+```yaml
+recorder:
+  exclude:
+    entity_globs:
+      - geo_location.abc_emergency_*
+    entities:
+      - sensor.abc_emergency_nsw_incidents_total  # If you don't need history
+```
+
+### Exclude from Logbook
+
+```yaml
+logbook:
+  exclude:
+    entity_globs:
+      - geo_location.abc_emergency_*
+```
+
+---
+
+## Security Considerations
+
+### Sensitive Data
+
+- ABC Emergency data is public
+- Your location data stays local
+- No authentication required for the API
+
+### Automation Safety
+
+Add confirmation for destructive actions:
+
+```yaml
+automation:
+  - alias: "Emergency Mode with Confirmation"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.abc_emergency_home_emergency_warning
+        to: "on"
+    action:
+      - service: notify.mobile_app_phone
+        data:
+          title: "Activate Emergency Mode?"
+          message: "Tap to confirm"
+          data:
+            actions:
+              - action: "ACTIVATE_EMERGENCY"
+                title: "Activate"
+              - action: "DISMISS"
+                title: "Dismiss"
+```
+
+---
+
+## Next Steps
+
+- [Automations Guide](automations.md) - Automation examples
+- [Scripts Guide](scripts.md) - Script examples
+- [Troubleshooting](troubleshooting.md) - Common issues
+- [Contributing](../CONTRIBUTING.md) - How to contribute

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -1,0 +1,606 @@
+# Automations Guide
+
+Ready-to-use Home Assistant automations for ABC Emergency alerts.
+
+> **Note:** All examples use placeholder entity names like `abc_emergency_home_*`. Replace `home` with your configured instance name.
+
+---
+
+## Basic Alert Notification
+
+The simplest automation - notify when any emergency warning is active near you.
+
+```yaml
+automation:
+  - id: abc_emergency_basic_alert
+    alias: "ABC Emergency - Basic Alert"
+    description: "Notify when any emergency warning is active nearby"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.abc_emergency_home_advice
+        to: "on"
+    action:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "Emergency Alert"
+          message: >
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+            ({{ states('sensor.abc_emergency_home_nearest_incident') }}km away)
+```
+
+---
+
+## Tiered Notifications by Warning Level
+
+Send different notification priorities based on the warning level.
+
+```yaml
+automation:
+  # Advice level - informational, normal priority
+  - id: abc_emergency_advice_notification
+    alias: "ABC Emergency - Advice Level"
+    description: "Informational notification for Advice level warnings"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.abc_emergency_home_advice
+        to: "on"
+    condition:
+      # Only trigger if this is exactly Advice level (not higher)
+      - condition: state
+        entity_id: binary_sensor.abc_emergency_home_watch_and_act
+        state: "off"
+    action:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "Emergency Advice"
+          message: >
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }}:
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+            ({{ states('sensor.abc_emergency_home_nearest_incident') }}km
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'direction') }})
+
+  # Watch and Act - urgent, high priority
+  - id: abc_emergency_watch_and_act_notification
+    alias: "ABC Emergency - Watch and Act"
+    description: "High priority notification for Watch and Act warnings"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.abc_emergency_home_watch_and_act
+        to: "on"
+    condition:
+      # Only trigger if this is exactly Watch and Act (not Emergency)
+      - condition: state
+        entity_id: binary_sensor.abc_emergency_home_emergency_warning
+        state: "off"
+    action:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "WATCH AND ACT"
+          message: >
+            Take action now!
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }}:
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+            is {{ states('sensor.abc_emergency_home_nearest_incident') }}km to the
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'direction') }}
+          data:
+            priority: high
+            ttl: 0
+            channel: alerts
+
+  # Emergency Warning - critical, bypass Do Not Disturb
+  - id: abc_emergency_emergency_warning_notification
+    alias: "ABC Emergency - Emergency Warning"
+    description: "Critical notification for Emergency Warning"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.abc_emergency_home_emergency_warning
+        to: "on"
+    action:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "EMERGENCY WARNING"
+          message: >
+            ACT IMMEDIATELY!
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }}:
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+            is {{ states('sensor.abc_emergency_home_nearest_incident') }}km to the
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'direction') }}
+          data:
+            priority: critical
+            ttl: 0
+            channel: alarm_stream
+```
+
+---
+
+## Distance-Based Escalation
+
+Increase urgency as an incident gets closer.
+
+```yaml
+automation:
+  # Warning when incident comes within 30km
+  - id: abc_emergency_distance_30km
+    alias: "ABC Emergency - Incident Within 30km"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.abc_emergency_home_nearest_incident
+        below: 30
+    action:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "Emergency Approaching"
+          message: >
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+            is now {{ states('sensor.abc_emergency_home_nearest_incident') }}km away
+
+  # Urgent when incident comes within 15km
+  - id: abc_emergency_distance_15km
+    alias: "ABC Emergency - Incident Within 15km"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.abc_emergency_home_nearest_incident
+        below: 15
+    action:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "EMERGENCY CLOSE BY"
+          message: >
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+            is now only {{ states('sensor.abc_emergency_home_nearest_incident') }}km away!
+          data:
+            priority: high
+
+  # Critical when incident comes within 5km
+  - id: abc_emergency_distance_5km
+    alias: "ABC Emergency - Incident Within 5km"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.abc_emergency_home_nearest_incident
+        below: 5
+    action:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "IMMEDIATE DANGER"
+          message: >
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+            is only {{ states('sensor.abc_emergency_home_nearest_incident') }}km away!
+            Consider evacuating!
+          data:
+            priority: critical
+            channel: alarm_stream
+```
+
+---
+
+## Family Member Safety Alerts
+
+Monitor emergencies near family members as they move.
+
+```yaml
+automation:
+  # Alert when Dad enters an emergency zone
+  - id: abc_emergency_dad_alert
+    alias: "ABC Emergency - Dad Near Emergency"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.abc_emergency_dad_active_alert
+        to: "on"
+    action:
+      - service: notify.family_group
+        data:
+          title: "Emergency Near Dad"
+          message: >
+            There's an active emergency near Dad's location.
+            {{ state_attr('sensor.abc_emergency_dad_nearest_incident', 'event_type') }}:
+            {{ state_attr('sensor.abc_emergency_dad_nearest_incident', 'headline') }}
+            Distance: {{ states('sensor.abc_emergency_dad_nearest_incident') }}km
+
+  # Alert for any family member with Emergency Warning
+  - id: abc_emergency_family_emergency_warning
+    alias: "ABC Emergency - Family Member Emergency Warning"
+    trigger:
+      - platform: state
+        entity_id:
+          - binary_sensor.abc_emergency_mum_emergency_warning
+          - binary_sensor.abc_emergency_dad_emergency_warning
+          - binary_sensor.abc_emergency_child_emergency_warning
+        to: "on"
+    action:
+      - service: notify.family_group
+        data:
+          title: "EMERGENCY WARNING - Family Member"
+          message: >
+            {{ trigger.to_state.name }} has an Emergency Warning active!
+            Check on them immediately.
+          data:
+            priority: critical
+```
+
+---
+
+## Quiet Hours Handling
+
+Adjust notification behavior during sleep hours.
+
+```yaml
+automation:
+  - id: abc_emergency_quiet_hours
+    alias: "ABC Emergency - Quiet Hours Aware"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.abc_emergency_home_advice
+        to: "on"
+    action:
+      - choose:
+          # During quiet hours (10pm - 7am): only notify for Watch and Act or higher
+          - conditions:
+              - condition: time
+                after: "22:00:00"
+                before: "07:00:00"
+              - condition: state
+                entity_id: binary_sensor.abc_emergency_home_watch_and_act
+                state: "on"
+            sequence:
+              - service: notify.mobile_app_your_phone
+                data:
+                  title: "URGENT: Emergency Alert"
+                  message: >
+                    {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+                    ({{ states('sensor.abc_emergency_home_nearest_incident') }}km)
+                  data:
+                    priority: critical
+          # During quiet hours: ignore Advice-only alerts
+          - conditions:
+              - condition: time
+                after: "22:00:00"
+                before: "07:00:00"
+            sequence: []  # Do nothing for Advice during quiet hours
+        # Normal hours: notify for everything
+        default:
+          - service: notify.mobile_app_your_phone
+            data:
+              title: "Emergency Alert"
+              message: >
+                {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+                ({{ states('sensor.abc_emergency_home_nearest_incident') }}km)
+```
+
+---
+
+## TTS Announcements
+
+Announce emergencies on smart speakers.
+
+```yaml
+automation:
+  # Announce on Google Home/Nest speakers
+  - id: abc_emergency_tts_google
+    alias: "ABC Emergency - TTS Announcement (Google)"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.abc_emergency_home_watch_and_act
+        to: "on"
+    action:
+      - service: tts.google_translate_say
+        target:
+          entity_id: media_player.living_room_speaker
+        data:
+          message: >
+            Attention! Emergency Alert.
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }}
+            detected {{ states('sensor.abc_emergency_home_nearest_incident') }} kilometres
+            to the {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'direction') }}.
+            Please check ABC Emergency for more information.
+
+  # Announce on Amazon Alexa
+  - id: abc_emergency_tts_alexa
+    alias: "ABC Emergency - TTS Announcement (Alexa)"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.abc_emergency_home_watch_and_act
+        to: "on"
+    action:
+      - service: notify.alexa_media
+        data:
+          target: media_player.kitchen_echo
+          message: >
+            <voice name="Nicole">
+            <amazon:emotion name="excited" intensity="high">
+            Attention! Emergency Alert!
+            </amazon:emotion>
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }}
+            detected {{ states('sensor.abc_emergency_home_nearest_incident') }} kilometres away.
+            </voice>
+          data:
+            type: announce
+```
+
+---
+
+## Smart Light Alerts
+
+Use your lights to indicate emergency status.
+
+```yaml
+automation:
+  # Flash lights red for Emergency Warning
+  - id: abc_emergency_lights_flash
+    alias: "ABC Emergency - Flash Lights Red"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.abc_emergency_home_emergency_warning
+        to: "on"
+    action:
+      - repeat:
+          count: 5
+          sequence:
+            - service: light.turn_on
+              target:
+                entity_id: light.living_room
+              data:
+                color_name: red
+                brightness: 255
+            - delay: "00:00:01"
+            - service: light.turn_off
+              target:
+                entity_id: light.living_room
+            - delay: "00:00:01"
+      - service: light.turn_on
+        target:
+          entity_id: light.living_room
+        data:
+          color_name: red
+          brightness: 128
+
+  # Set light color based on warning level
+  - id: abc_emergency_lights_color
+    alias: "ABC Emergency - Warning Level Light Color"
+    trigger:
+      - platform: state
+        entity_id: sensor.abc_emergency_home_highest_alert_level
+    action:
+      - choose:
+          - conditions:
+              - condition: state
+                entity_id: sensor.abc_emergency_home_highest_alert_level
+                state: "Emergency"
+            sequence:
+              - service: light.turn_on
+                target:
+                  entity_id: light.status_lamp
+                data:
+                  color_name: red
+                  brightness: 255
+          - conditions:
+              - condition: state
+                entity_id: sensor.abc_emergency_home_highest_alert_level
+                state: "Watch and Act"
+            sequence:
+              - service: light.turn_on
+                target:
+                  entity_id: light.status_lamp
+                data:
+                  rgb_color: [255, 165, 0]  # Orange
+                  brightness: 255
+          - conditions:
+              - condition: state
+                entity_id: sensor.abc_emergency_home_highest_alert_level
+                state: "Advice"
+            sequence:
+              - service: light.turn_on
+                target:
+                  entity_id: light.status_lamp
+                data:
+                  color_name: yellow
+                  brightness: 200
+        default:
+          - service: light.turn_off
+            target:
+              entity_id: light.status_lamp
+```
+
+---
+
+## Bushfire-Specific Alerts
+
+Alert specifically for bushfire incidents.
+
+```yaml
+automation:
+  - id: abc_emergency_bushfire_alert
+    alias: "ABC Emergency - Bushfire Alert"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.abc_emergency_home_bushfires
+        above: 0
+    action:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "Bushfire Alert"
+          message: >
+            {{ states('sensor.abc_emergency_home_bushfires') }} active bushfire(s) in your area.
+            Nearest incident: {{ states('sensor.abc_emergency_home_nearest_incident') }}km away.
+
+  - id: abc_emergency_bushfire_close
+    alias: "ABC Emergency - Bushfire Close By"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.abc_emergency_home_nearest_incident
+        below: 20
+    condition:
+      - condition: template
+        value_template: >
+          {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') == 'Bushfire' }}
+    action:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "BUSHFIRE CLOSE BY"
+          message: >
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+            is {{ states('sensor.abc_emergency_home_nearest_incident') }}km
+            to the {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'direction') }}!
+            Monitor conditions closely.
+          data:
+            priority: high
+            channel: alerts
+```
+
+---
+
+## Siren/Alarm Activation
+
+Activate external sirens for critical emergencies.
+
+```yaml
+automation:
+  - id: abc_emergency_siren
+    alias: "ABC Emergency - Activate Siren"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.abc_emergency_home_emergency_warning
+        to: "on"
+    condition:
+      # Only during waking hours unless very close
+      - condition: or
+        conditions:
+          - condition: time
+            after: "07:00:00"
+            before: "22:00:00"
+          - condition: numeric_state
+            entity_id: sensor.abc_emergency_home_nearest_incident
+            below: 5
+    action:
+      - service: switch.turn_on
+        target:
+          entity_id: switch.emergency_siren
+      - delay: "00:00:30"  # Sound for 30 seconds
+      - service: switch.turn_off
+        target:
+          entity_id: switch.emergency_siren
+```
+
+---
+
+## All-Clear Notification
+
+Notify when an emergency threat has passed.
+
+```yaml
+automation:
+  - id: abc_emergency_all_clear
+    alias: "ABC Emergency - All Clear"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.abc_emergency_home_active_alert
+        from: "on"
+        to: "off"
+    action:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "All Clear"
+          message: >
+            No active emergencies near your location.
+            Stay safe and remain vigilant.
+```
+
+---
+
+## Multi-Zone Monitoring
+
+Monitor multiple locations and summarize.
+
+```yaml
+automation:
+  - id: abc_emergency_multi_zone_summary
+    alias: "ABC Emergency - Multi-Zone Summary"
+    trigger:
+      - platform: time
+        at: "08:00:00"  # Daily morning summary
+    condition:
+      - condition: or
+        conditions:
+          - condition: state
+            entity_id: binary_sensor.abc_emergency_home_active_alert
+            state: "on"
+          - condition: state
+            entity_id: binary_sensor.abc_emergency_office_active_alert
+            state: "on"
+          - condition: state
+            entity_id: binary_sensor.abc_emergency_beach_house_active_alert
+            state: "on"
+    action:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "Morning Emergency Summary"
+          message: >
+            Active emergencies:
+            Home: {{ states('sensor.abc_emergency_home_incidents_nearby') }} nearby
+            Office: {{ states('sensor.abc_emergency_office_incidents_nearby') }} nearby
+            Beach House: {{ states('sensor.abc_emergency_beach_house_incidents_nearby') }} nearby
+```
+
+---
+
+## Blueprint Template
+
+Use this as a starting point for custom automations:
+
+```yaml
+automation:
+  - id: abc_emergency_custom
+    alias: "ABC Emergency - Custom Automation"
+    description: "Describe your automation purpose"
+
+    trigger:
+      # Choose your trigger type:
+
+      # Option 1: Warning level change
+      - platform: state
+        entity_id: binary_sensor.abc_emergency_home_advice
+        to: "on"
+
+      # Option 2: Distance threshold
+      # - platform: numeric_state
+      #   entity_id: sensor.abc_emergency_home_nearest_incident
+      #   below: 25
+
+      # Option 3: Incident count increase
+      # - platform: numeric_state
+      #   entity_id: sensor.abc_emergency_home_bushfires
+      #   above: 0
+
+    condition:
+      # Optional conditions:
+
+      # Time-based
+      # - condition: time
+      #   after: "07:00:00"
+      #   before: "22:00:00"
+
+      # Event type filter
+      # - condition: template
+      #   value_template: >
+      #     {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') == 'Bushfire' }}
+
+    action:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "Your Title"
+          message: >
+            Your message using:
+            - Headline: {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+            - Distance: {{ states('sensor.abc_emergency_home_nearest_incident') }}km
+            - Direction: {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'direction') }}
+            - Type: {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }}
+            - Level: {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'alert_level') }}
+```
+
+---
+
+## Next Steps
+
+- [Notifications Guide](notifications.md) - Detailed notification setup
+- [Scripts Guide](scripts.md) - Emergency scripts and sequences
+- [Entities Reference](entities.md) - Complete entity documentation
+- [Troubleshooting](troubleshooting.md) - Common issues and solutions

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,374 @@
+# Configuration Guide
+
+This guide covers all configuration options for ABC Emergency for Home Assistant.
+
+---
+
+## Configuration Overview
+
+ABC Emergency supports three monitoring modes, each with different configuration options:
+
+| Mode | Purpose | Location Source |
+|------|---------|-----------------|
+| **State Mode** | Monitor all incidents in a state/territory | Fixed state boundary |
+| **Zone Mode** | Monitor incidents near a fixed location | User-defined coordinates |
+| **Person Mode** | Monitor incidents near a moving person | Person entity's GPS location |
+
+---
+
+## State Mode Configuration
+
+State Mode monitors all emergencies in an Australian state or territory.
+
+### Initial Setup
+
+1. Select **"Monitor a State/Territory"**
+2. Choose your state:
+   - `nsw` - New South Wales
+   - `vic` - Victoria
+   - `qld` - Queensland
+   - `sa` - South Australia
+   - `wa` - Western Australia
+   - `tas` - Tasmania
+   - `nt` - Northern Territory
+   - `act` - Australian Capital Territory
+
+### State Mode Options
+
+State Mode has minimal configuration - just the state selection. There's no radius configuration because it monitors the entire state.
+
+### Best Use Cases
+
+- Getting a complete picture of emergency activity in your state
+- Situational awareness during fire seasons
+- Monitoring conditions before travel
+- News/media monitoring
+
+### Entities Created
+
+- `sensor.abc_emergency_[state]_incidents_total`
+- `sensor.abc_emergency_[state]_highest_alert_level`
+- `sensor.abc_emergency_[state]_bushfires`
+- `sensor.abc_emergency_[state]_floods`
+- `sensor.abc_emergency_[state]_storms`
+- `binary_sensor.abc_emergency_[state]_active_alert`
+- `binary_sensor.abc_emergency_[state]_emergency_warning`
+- `binary_sensor.abc_emergency_[state]_watch_and_act`
+- `binary_sensor.abc_emergency_[state]_advice`
+
+---
+
+## Zone Mode Configuration
+
+Zone Mode monitors emergencies within configurable distances of a fixed location.
+
+### Initial Setup
+
+1. Select **"Monitor a fixed location (zone)"**
+2. Enter a **name** for the zone (e.g., "Home", "Office", "Farm")
+3. Set the **location**:
+   - Click on the map to set coordinates, OR
+   - Enter latitude and longitude manually
+4. Configure **alert radii** for each incident type
+
+### Zone Name
+
+The zone name becomes part of entity IDs:
+- Name: "Home" → `sensor.abc_emergency_home_incidents_total`
+- Name: "Beach House" → `sensor.abc_emergency_beach_house_incidents_total`
+
+Use descriptive names that are easy to identify in automations.
+
+### Location Selection
+
+You can set the location by:
+
+1. **Clicking on the map** - Zoom to your location and click
+2. **Manual coordinates** - Enter latitude (e.g., `-33.8688`) and longitude (e.g., `151.2093`)
+3. **Using Home Assistant zones** - If you have zones configured, you can match coordinates
+
+### Per-Incident-Type Radius
+
+Different emergency types have different area impacts. Zone Mode lets you configure separate alert radii for each type:
+
+| Incident Type | Default | Range | Rationale |
+|---------------|---------|-------|-----------|
+| **Bushfire** | 50 km | 5-200 km | Can spread rapidly; smoke and ember attack extend far |
+| **Earthquake** | 100 km | 10-500 km | Seismic effects felt over large distances |
+| **Storm** | 75 km | 10-200 km | Severe storms cover broad areas |
+| **Flood** | 30 km | 5-100 km | Typically more localized to waterways |
+| **Structure Fire** | 10 km | 1-50 km | Rarely affects distant areas unless major |
+| **Extreme Heat** | 100 km | 20-200 km | Heatwaves are regional events |
+| **Other** | 25 km | 5-100 km | Balanced default for miscellaneous |
+
+#### Adjusting Radii
+
+Consider adjusting based on:
+
+- **Rural vs urban** - Rural areas may need larger radii due to spread potential
+- **Local geography** - Valleys may channel smoke/fire; coastal areas have different risks
+- **Personal risk tolerance** - Increase for earlier warning; decrease to reduce noise
+- **Historical events** - Past incidents in your area can guide appropriate distances
+
+### Modifying Zone Options
+
+After initial setup, you can modify options:
+
+1. Go to **Settings** → **Devices & Services**
+2. Find **ABC Emergency**
+3. Click on your Zone instance
+4. Click **Configure**
+5. Adjust radii as needed
+6. Click **Submit**
+
+### Entities Created
+
+Zone Mode creates all State Mode entities plus:
+
+- `sensor.abc_emergency_[name]_incidents_nearby` - Count within radii
+- `sensor.abc_emergency_[name]_nearest_incident` - Distance in km
+
+---
+
+## Person Mode Configuration
+
+Person Mode monitors emergencies near a person's current location as they move.
+
+### Prerequisites
+
+You need a `person.*` entity with location tracking:
+
+1. **Home Assistant Companion App** - Provides GPS location
+2. **Device trackers** - GPS-based trackers linked to a person
+3. **Other location sources** - Any device tracker assigned to a person
+
+### Initial Setup
+
+1. Select **"Monitor a person's location"**
+2. Choose the **person entity** from the dropdown
+3. Configure **alert radii** for each incident type (same options as Zone Mode)
+
+### Person Entity Selection
+
+Only `person.*` entities with location tracking appear in the dropdown. If your person doesn't appear:
+
+1. Ensure the person has a device tracker assigned
+2. Verify the device tracker is reporting location
+3. Check **Developer Tools** → **States** for `person.*` entities with `latitude`/`longitude` attributes
+
+### How Location Updates Work
+
+1. The person entity's location updates (via mobile app, etc.)
+2. ABC Emergency checks for incidents near the new location
+3. Entities update to reflect incidents near the person's current position
+
+**Update frequency:** The integration polls every 5 minutes. Location updates are processed on the next poll.
+
+### Privacy Considerations
+
+- Person Mode uses existing Home Assistant location data
+- No additional tracking is introduced
+- Location data stays within your Home Assistant instance
+- The integration only reads location; it doesn't track or store history
+
+### Best Use Cases
+
+- Family safety monitoring
+- Alerting when someone travels into an emergency zone
+- Peace of mind for family members
+- Traveler safety
+
+### Entities Created
+
+Same as Zone Mode, with entity names based on the person:
+
+- `sensor.abc_emergency_[person]_nearest_incident`
+- `binary_sensor.abc_emergency_[person]_emergency_warning`
+- etc.
+
+---
+
+## Multiple Instances
+
+You can run multiple instances of ABC Emergency simultaneously.
+
+### Adding Another Instance
+
+1. Go to **Settings** → **Devices & Services**
+2. Click **ABC Emergency**
+3. Click **+ Add Entry**
+4. Configure the new instance
+
+### Example Multi-Instance Setups
+
+#### Family Safety Setup
+
+| Instance | Mode | Purpose |
+|----------|------|---------|
+| NSW Overview | State | See all NSW emergencies |
+| Home | Zone | Alerts for home location |
+| Mum | Person | Track alerts near Mum |
+| Dad | Person | Track alerts near Dad |
+
+#### Property Portfolio
+
+| Instance | Mode | Purpose |
+|----------|------|---------|
+| Primary Residence | Zone | Main home |
+| Investment Property | Zone | Rental property |
+| Holiday House | Zone | Coastal property |
+| Farm | Zone | Rural property |
+
+#### Traveler Setup
+
+| Instance | Mode | Purpose |
+|----------|------|---------|
+| VIC | State | Home state overview |
+| NSW | State | Neighboring state |
+| QLD | State | Holiday destination |
+| Self | Person | Personal location tracking |
+
+### Instance Naming Best Practices
+
+- Use descriptive, unique names
+- Avoid special characters in names
+- Keep names concise for entity IDs
+- Consider how names will appear in automations
+
+---
+
+## Options Flow (Post-Setup Changes)
+
+Most configuration can be modified after setup without removing the integration.
+
+### Accessing Options
+
+1. **Settings** → **Devices & Services**
+2. Find **ABC Emergency**
+3. Click on the specific instance
+4. Click **Configure**
+
+### What Can Be Changed
+
+| Mode | Changeable Options |
+|------|-------------------|
+| State | State selection |
+| Zone | Alert radii (not location) |
+| Person | Alert radii, person entity |
+
+### What Requires Reconfiguration
+
+To change these, remove and re-add the instance:
+
+- Zone location (coordinates)
+- Zone name
+- Switching between modes
+
+---
+
+## Update Interval
+
+The integration polls ABC Emergency data at a fixed 5-minute interval.
+
+### Why 5 Minutes?
+
+- Balances timeliness with responsible API usage
+- Emergency data typically updates every few minutes at the source
+- Provides near-real-time awareness without overwhelming the data source
+
+### Cannot Be Changed
+
+The update interval is not configurable. This ensures:
+- Consistent behavior across all installations
+- Respectful use of the public ABC Emergency service
+- Reliable data freshness for emergency purposes
+
+---
+
+## Data Refresh
+
+### Manual Refresh
+
+If you need to force a data refresh:
+
+1. Go to **Developer Tools** → **Services**
+2. Search for `homeassistant.update_entity`
+3. Select your ABC Emergency sensor entity
+4. Click **Call Service**
+
+### Automatic Refresh
+
+Data refreshes automatically:
+- Every 5 minutes
+- After Home Assistant restart
+- After configuration changes
+
+---
+
+## Configuration Examples
+
+### Minimal Setup (State Mode)
+
+Just monitoring NSW:
+
+```
+Mode: State
+State: NSW
+```
+
+Creates entities like `sensor.abc_emergency_nsw_incidents_total`.
+
+### Home Monitoring (Zone Mode)
+
+Monitoring your home in Sydney:
+
+```
+Mode: Zone
+Name: Home
+Latitude: -33.8688
+Longitude: 151.2093
+Radii:
+  Bushfire: 50 km
+  Earthquake: 100 km
+  Storm: 75 km
+  Flood: 30 km
+  Structure Fire: 10 km
+  Extreme Heat: 100 km
+  Other: 25 km
+```
+
+### Rural Property (Zone Mode with Larger Radii)
+
+Monitoring a farm in rural Victoria:
+
+```
+Mode: Zone
+Name: Farm
+Latitude: -37.5500
+Longitude: 143.8500
+Radii:
+  Bushfire: 100 km    # Increased for rural fire spread
+  Earthquake: 150 km
+  Storm: 100 km
+  Flood: 50 km        # Increased for river catchment
+  Structure Fire: 20 km
+  Extreme Heat: 150 km
+  Other: 50 km
+```
+
+### Family Member Tracking (Person Mode)
+
+Monitoring emergencies near a family member:
+
+```
+Mode: Person
+Person: person.dad
+Radii:
+  Bushfire: 30 km     # Reduced for urban travel
+  Earthquake: 100 km
+  Storm: 50 km
+  Flood: 20 km
+  Structure Fire: 5 km
+  Extreme Heat: 100 km
+  Other: 15 km
+```

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -1,0 +1,435 @@
+# Entities Reference
+
+Complete documentation for all entities created by ABC Emergency for Home Assistant.
+
+---
+
+## Entity Naming Convention
+
+All entities follow the naming pattern:
+
+```
+{domain}.abc_emergency_{instance_name}_{entity_key}
+```
+
+Where:
+- `{domain}` - `sensor`, `binary_sensor`, or `geo_location`
+- `{instance_name}` - Your configured name (e.g., "home", "nsw", "dad")
+- `{entity_key}` - The specific entity type (e.g., "incidents_total")
+
+**Examples:**
+- `sensor.abc_emergency_home_incidents_total`
+- `binary_sensor.abc_emergency_nsw_emergency_warning`
+- `sensor.abc_emergency_dad_nearest_incident`
+
+---
+
+## Sensors
+
+### All Instance Types
+
+These sensors are created for State, Zone, and Person modes.
+
+#### incidents_total
+
+| Property | Value |
+|----------|-------|
+| **Entity ID** | `sensor.abc_emergency_*_incidents_total` |
+| **State** | Integer count of total active incidents |
+| **State Class** | `measurement` |
+| **Unit** | None |
+
+**Description:** Total count of all active emergency incidents in the monitored area. For State mode, this is the entire state. For Zone/Person modes, this is all incidents in the state (not filtered by radius).
+
+**Example state:** `42`
+
+---
+
+#### highest_alert_level
+
+| Property | Value |
+|----------|-------|
+| **Entity ID** | `sensor.abc_emergency_*_highest_alert_level` |
+| **State** | Alert level string |
+| **State Class** | None |
+| **Unit** | None |
+
+**Description:** The highest active alert level in the monitored area.
+
+**Possible states:**
+| State | Australian Warning System | Meaning |
+|-------|---------------------------|---------|
+| `Emergency` | Emergency Warning (Red) | Highest level - immediate danger |
+| `Watch and Act` | Watch and Act (Orange) | Heightened threat - prepare to act |
+| `Advice` | Advice (Yellow) | Incident occurring - stay informed |
+| `none` | No active alerts | No warnings currently active |
+
+**Example state:** `Watch and Act`
+
+---
+
+#### bushfires
+
+| Property | Value |
+|----------|-------|
+| **Entity ID** | `sensor.abc_emergency_*_bushfires` |
+| **State** | Integer count |
+| **State Class** | `measurement` |
+| **Unit** | None |
+
+**Description:** Count of active bushfire/grass fire incidents.
+
+**Example state:** `7`
+
+---
+
+#### floods
+
+| Property | Value |
+|----------|-------|
+| **Entity ID** | `sensor.abc_emergency_*_floods` |
+| **State** | Integer count |
+| **State Class** | `measurement` |
+| **Unit** | None |
+
+**Description:** Count of active flood incidents.
+
+**Example state:** `3`
+
+---
+
+#### storms
+
+| Property | Value |
+|----------|-------|
+| **Entity ID** | `sensor.abc_emergency_*_storms` |
+| **State** | Integer count |
+| **State Class** | `measurement` |
+| **Unit** | None |
+
+**Description:** Count of active storm/severe weather incidents.
+
+**Example state:** `12`
+
+---
+
+### Zone/Person Mode Only
+
+These sensors are only created for Zone and Person mode instances (not State mode).
+
+#### incidents_nearby
+
+| Property | Value |
+|----------|-------|
+| **Entity ID** | `sensor.abc_emergency_*_incidents_nearby` |
+| **State** | Integer count |
+| **State Class** | `measurement` |
+| **Unit** | None |
+
+**Description:** Count of incidents within your configured alert radii. Different incident types have different radii (e.g., bushfires 50km, structure fires 10km).
+
+**Example state:** `2`
+
+---
+
+#### nearest_incident
+
+| Property | Value |
+|----------|-------|
+| **Entity ID** | `sensor.abc_emergency_*_nearest_incident` |
+| **State** | Distance in kilometers |
+| **Device Class** | `distance` |
+| **State Class** | `measurement` |
+| **Unit** | `km` |
+
+**Description:** Distance to the nearest emergency incident from your monitored location.
+
+**State:** Numeric value in kilometers, rounded to 1 decimal place. Returns `unknown` if no incidents exist.
+
+**Example state:** `12.4`
+
+**Attributes:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `headline` | string | Brief description of the incident |
+| `alert_level` | string | Warning level (Emergency, Watch and Act, Advice) |
+| `event_type` | string | Type of incident (Bushfire, Flood, Storm, etc.) |
+| `direction` | string | Compass direction to the incident (N, NE, E, etc.) |
+
+**Example attributes:**
+```yaml
+headline: "Milsons Gully"
+alert_level: "Emergency"
+event_type: "Bushfire"
+direction: "NW"
+```
+
+---
+
+## Binary Sensors
+
+Binary sensors are created for all instance types and are ideal for automations.
+
+### active_alert
+
+| Property | Value |
+|----------|-------|
+| **Entity ID** | `binary_sensor.abc_emergency_*_active_alert` |
+| **Device Class** | `safety` |
+| **On when** | Any incident is active |
+
+**Description:** Indicates whether there are any active emergency incidents in your monitored area.
+
+**Behavior by mode:**
+- **State mode:** On when `incidents_total > 0`
+- **Zone/Person mode:** On when `incidents_nearby > 0` (within your radii)
+
+---
+
+### emergency_warning
+
+| Property | Value |
+|----------|-------|
+| **Entity ID** | `binary_sensor.abc_emergency_*_emergency_warning` |
+| **Device Class** | `safety` |
+| **On when** | Emergency Warning (red) level active |
+
+**Description:** Indicates the highest alert level - Emergency Warning. This means you may be in danger and should act immediately.
+
+**Attributes (when on):**
+
+For Zone/Person modes:
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `count` | integer | Number of Emergency Warning incidents |
+| `nearest_headline` | string | Description of nearest red-level incident |
+| `nearest_distance_km` | float | Distance to nearest in km |
+| `nearest_direction` | string | Compass direction |
+
+For State mode:
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `count` | integer | Total Emergency Warning incidents in state |
+| `headline` | string | Description of first red-level incident |
+
+---
+
+### watch_and_act
+
+| Property | Value |
+|----------|-------|
+| **Entity ID** | `binary_sensor.abc_emergency_*_watch_and_act` |
+| **Device Class** | `safety` |
+| **On when** | Watch and Act (orange) OR Emergency Warning (red) active |
+
+**Description:** Indicates Watch and Act level or higher. Conditions are changing and you should prepare to take action.
+
+**Note:** This sensor is "on" for both Watch and Act AND Emergency Warning levels, making it useful for "at least this severity" automations.
+
+**Attributes:** Same structure as `emergency_warning`, but includes incidents at both levels.
+
+---
+
+### advice
+
+| Property | Value |
+|----------|-------|
+| **Entity ID** | `binary_sensor.abc_emergency_*_advice` |
+| **Device Class** | `safety` |
+| **On when** | Any warning level active (Advice, Watch and Act, or Emergency Warning) |
+
+**Description:** Indicates any official warning is active. An incident has started and you should stay informed.
+
+**Note:** This is the most sensitive alert level - it turns on for any official warning.
+
+---
+
+## Binary Sensor Hierarchy
+
+The binary sensors form a hierarchy where higher-level sensors also trigger lower ones:
+
+```
+emergency_warning: ON → watch_and_act: ON → advice: ON → active_alert: ON
+```
+
+| Scenario | emergency_warning | watch_and_act | advice | active_alert |
+|----------|-------------------|---------------|--------|--------------|
+| No incidents | OFF | OFF | OFF | OFF |
+| Minor incident (no warning) | OFF | OFF | OFF | ON |
+| Advice level | OFF | OFF | ON | ON |
+| Watch and Act | OFF | ON | ON | ON |
+| Emergency Warning | ON | ON | ON | ON |
+
+---
+
+## Geo-Location Entities
+
+When enabled, the integration creates geo-location entities for mapping incidents.
+
+### Geo-Location Entity
+
+| Property | Value |
+|----------|-------|
+| **Entity ID** | `geo_location.abc_emergency_*_{incident_id}` |
+| **State** | Distance in km |
+| **Latitude** | Incident location |
+| **Longitude** | Incident location |
+
+**Attributes:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `source` | string | Always `abc_emergency` |
+| `headline` | string | Incident description |
+| `alert_level` | string | Warning level |
+| `event_type` | string | Type of incident |
+| `status` | string | Current incident status |
+| `size` | string | Affected area size (for fires) |
+
+---
+
+## Using Entities in Automations
+
+### Triggering on Warning Levels
+
+```yaml
+# Trigger on any warning
+trigger:
+  - platform: state
+    entity_id: binary_sensor.abc_emergency_home_advice
+    to: "on"
+
+# Trigger on Watch and Act or higher
+trigger:
+  - platform: state
+    entity_id: binary_sensor.abc_emergency_home_watch_and_act
+    to: "on"
+
+# Trigger only on Emergency Warning
+trigger:
+  - platform: state
+    entity_id: binary_sensor.abc_emergency_home_emergency_warning
+    to: "on"
+```
+
+### Triggering on Distance
+
+```yaml
+# Trigger when nearest incident is within 20km
+trigger:
+  - platform: numeric_state
+    entity_id: sensor.abc_emergency_home_nearest_incident
+    below: 20
+
+# Trigger when nearest incident gets closer than 10km
+trigger:
+  - platform: numeric_state
+    entity_id: sensor.abc_emergency_home_nearest_incident
+    below: 10
+```
+
+### Using Attributes in Messages
+
+```yaml
+action:
+  - service: notify.mobile_app_phone
+    data:
+      title: "Emergency Alert"
+      message: >
+        {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+        is {{ states('sensor.abc_emergency_home_nearest_incident') }}km to the
+        {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'direction') }}
+```
+
+### Conditional Logic Based on Event Type
+
+```yaml
+condition:
+  - condition: template
+    value_template: >
+      {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') == 'Bushfire' }}
+```
+
+---
+
+## Entity State Diagrams
+
+### Binary Sensor State Flow
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                    No Active Incidents                       │
+│                                                              │
+│  active_alert: OFF    advice: OFF    watch_and_act: OFF      │
+│  emergency_warning: OFF                                      │
+└────────────────────────────┬─────────────────────────────────┘
+                             │ Incident starts
+                             ▼
+┌──────────────────────────────────────────────────────────────┐
+│                    Minor Incident (no warning)               │
+│                                                              │
+│  active_alert: ON     advice: OFF    watch_and_act: OFF      │
+│  emergency_warning: OFF                                      │
+└────────────────────────────┬─────────────────────────────────┘
+                             │ Advice warning issued
+                             ▼
+┌──────────────────────────────────────────────────────────────┐
+│                    Advice Level                              │
+│                                                              │
+│  active_alert: ON     advice: ON     watch_and_act: OFF      │
+│  emergency_warning: OFF                                      │
+└────────────────────────────┬─────────────────────────────────┘
+                             │ Upgraded to Watch and Act
+                             ▼
+┌──────────────────────────────────────────────────────────────┐
+│                    Watch and Act Level                       │
+│                                                              │
+│  active_alert: ON     advice: ON     watch_and_act: ON       │
+│  emergency_warning: OFF                                      │
+└────────────────────────────┬─────────────────────────────────┘
+                             │ Upgraded to Emergency Warning
+                             ▼
+┌──────────────────────────────────────────────────────────────┐
+│                    Emergency Warning Level                   │
+│                                                              │
+│  active_alert: ON     advice: ON     watch_and_act: ON       │
+│  emergency_warning: ON                                       │
+└──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Event Types
+
+The `event_type` attribute can contain various values depending on the incident:
+
+| Event Type | Description |
+|------------|-------------|
+| `Bushfire` | Bush or grass fire |
+| `Structure Fire` | Building fire |
+| `Flood` | Flooding event |
+| `Storm` | Severe storm |
+| `Thunderstorm` | Electrical storm |
+| `Earthquake` | Seismic event |
+| `Extreme Heat` | Heatwave warning |
+| `Heatwave` | Extended heat event |
+| `Cyclone` | Tropical cyclone |
+| `Planned Burn` | Hazard reduction burn |
+| `Burn Off` | Controlled burn |
+| `Other` | Miscellaneous events |
+
+---
+
+## Diagnostic Information
+
+For troubleshooting, entities include diagnostic information accessible via:
+
+**Settings** → **Devices & Services** → **ABC Emergency** → **[Your Instance]** → **Download Diagnostics**
+
+This includes:
+- Current sensor states
+- Cached incident data
+- Configuration options
+- Last update timestamp
+- API response information

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,234 @@
+# Getting Started with ABC Emergency
+
+This guide walks you through installing and configuring ABC Emergency for Home Assistant.
+
+---
+
+## Prerequisites
+
+Before installing, ensure you have:
+
+- **Home Assistant** 2024.1.0 or newer
+- **HACS** (Home Assistant Community Store) installed - [Install HACS](https://hacs.xyz/docs/setup/download)
+- An Australian location configured in Home Assistant (for Zone/Person modes)
+
+---
+
+## Installation
+
+### Method 1: HACS (Recommended)
+
+HACS makes installation and updates easy.
+
+#### Step 1: Add Custom Repository
+
+1. Open Home Assistant
+2. Navigate to **HACS** in the sidebar
+3. Click the **three dots menu** (⋮) in the top right
+4. Select **Custom repositories**
+5. Enter the repository URL:
+   ```
+   https://github.com/troykelly/homeassistant-abcemergency
+   ```
+6. Select **Integration** as the category
+7. Click **Add**
+
+#### Step 2: Install the Integration
+
+1. In HACS, click **Integrations**
+2. Click **Explore & Download Repositories**
+3. Search for **ABC Emergency**
+4. Click on it, then click **Download**
+5. Choose the latest version
+6. Click **Download**
+
+#### Step 3: Restart Home Assistant
+
+1. Go to **Settings** → **System** → **Restart**
+2. Click **Restart**
+3. Wait for Home Assistant to fully restart
+
+### Method 2: Manual Installation
+
+If you prefer not to use HACS:
+
+1. Download the [latest release](https://github.com/troykelly/homeassistant-abcemergency/releases)
+2. Extract the ZIP file
+3. Copy the `custom_components/abcemergency` folder to your Home Assistant's `custom_components` directory
+   ```
+   /config/custom_components/abcemergency/
+   ```
+4. Restart Home Assistant
+
+---
+
+## Adding the Integration
+
+After installation and restart:
+
+1. Go to **Settings** → **Devices & Services**
+2. Click **+ Add Integration** (bottom right)
+3. Search for **ABC Emergency**
+4. Click on it to begin setup
+
+---
+
+## Configuration Wizard
+
+The setup wizard guides you through configuring your monitoring preferences.
+
+### Step 1: Choose Monitoring Mode
+
+You'll be asked to select how you want to monitor emergencies:
+
+| Option | Use Case |
+|--------|----------|
+| **Monitor a State/Territory** | See all emergencies in a state (NSW, VIC, QLD, etc.) |
+| **Monitor a fixed location (zone)** | Get alerts within a radius of a specific location |
+| **Monitor a person's location** | Track alerts near a person as they move |
+
+### Step 2: Configure Your Choice
+
+#### For State Mode
+
+1. Select your state from the dropdown:
+   - New South Wales (NSW)
+   - Victoria (VIC)
+   - Queensland (QLD)
+   - South Australia (SA)
+   - Western Australia (WA)
+   - Tasmania (TAS)
+   - Northern Territory (NT)
+   - Australian Capital Territory (ACT)
+2. Click **Submit**
+
+#### For Zone Mode
+
+1. Enter a **name** for this zone (e.g., "Home", "Office", "Beach House")
+2. Select the location on the map, or enter coordinates manually
+3. Configure **alert radii** for each incident type (optional - defaults shown below):
+
+| Incident Type | Default Radius | Why |
+|---------------|----------------|-----|
+| Bushfire | 50 km | Bushfires can spread rapidly and affect large areas |
+| Earthquake | 100 km | Seismic events are felt over wide distances |
+| Storm | 75 km | Severe storms affect broad regions |
+| Flood | 30 km | Floods are typically more localized |
+| Structure Fire | 10 km | Structure fires rarely affect distant areas |
+| Extreme Heat | 100 km | Heatwaves cover entire regions |
+| Other | 25 km | Balanced default for miscellaneous incidents |
+
+4. Click **Submit**
+
+#### For Person Mode
+
+1. Select a **person entity** from the dropdown
+   - This must be a `person.*` entity configured in Home Assistant
+   - The person entity tracks location via mobile app or device trackers
+2. Configure **alert radii** for each incident type (same defaults as Zone Mode)
+3. Click **Submit**
+
+---
+
+## Verifying Installation
+
+After configuration, verify everything is working:
+
+### Check the Device
+
+1. Go to **Settings** → **Devices & Services**
+2. Find **ABC Emergency**
+3. Click on your configured instance
+4. You should see a device with multiple entities
+
+### Check the Entities
+
+Navigate to **Developer Tools** → **States** and search for `abc_emergency`. You should see:
+
+**Sensors:**
+- `sensor.abc_emergency_[name]_incidents_total` - Total incidents in monitored area
+- `sensor.abc_emergency_[name]_highest_alert_level` - Current highest warning level
+- `sensor.abc_emergency_[name]_bushfires` - Active bushfire count
+- `sensor.abc_emergency_[name]_floods` - Active flood count
+- `sensor.abc_emergency_[name]_storms` - Active storm count
+
+**For Zone/Person modes only:**
+- `sensor.abc_emergency_[name]_incidents_nearby` - Incidents within your radii
+- `sensor.abc_emergency_[name]_nearest_incident` - Distance to nearest incident
+
+**Binary Sensors:**
+- `binary_sensor.abc_emergency_[name]_active_alert` - Any alert active
+- `binary_sensor.abc_emergency_[name]_emergency_warning` - Red level alert
+- `binary_sensor.abc_emergency_[name]_watch_and_act` - Orange level or higher
+- `binary_sensor.abc_emergency_[name]_advice` - Yellow level or higher
+
+### Check the Map
+
+If using Zone or Person mode with geo-location entities enabled:
+
+1. Go to your Home Assistant **Map**
+2. You should see markers for active incidents in your monitored area
+
+---
+
+## Adding Multiple Instances
+
+You can add multiple instances to monitor different areas:
+
+1. Go to **Settings** → **Devices & Services**
+2. Click **ABC Emergency**
+3. Click **+ Add Entry**
+4. Configure the new instance
+
+**Example configurations:**
+
+- One State instance for NSW overview + one Zone instance for your home
+- Zone instances for home, office, and holiday house
+- Person instances for each family member
+
+---
+
+## Next Steps
+
+Now that you're set up:
+
+1. **[Configure notifications](notifications.md)** - Set up mobile alerts
+2. **[Create automations](automations.md)** - Automate your emergency response
+3. **[Explore entities](entities.md)** - Understand all available data
+4. **[Troubleshoot issues](troubleshooting.md)** - If something's not working
+
+---
+
+## Updating the Integration
+
+### Via HACS
+
+1. Open HACS
+2. Go to **Integrations**
+3. If an update is available, you'll see a notification
+4. Click **Update**
+5. Restart Home Assistant
+
+### Manual Update
+
+1. Download the new release
+2. Replace the contents of `custom_components/abcemergency`
+3. Restart Home Assistant
+
+---
+
+## Uninstalling
+
+### Via HACS
+
+1. Open HACS → **Integrations**
+2. Find **ABC Emergency**
+3. Click the three dots menu → **Remove**
+4. Remove the integration from **Settings** → **Devices & Services**
+5. Restart Home Assistant
+
+### Manual
+
+1. Delete the `custom_components/abcemergency` folder
+2. Remove the integration from **Settings** → **Devices & Services**
+3. Restart Home Assistant

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,635 @@
+# Notifications Guide
+
+Comprehensive guide to setting up emergency notifications with ABC Emergency for Home Assistant.
+
+---
+
+## Overview
+
+Emergency notifications are the primary way most users will interact with this integration. This guide covers:
+
+- Mobile app notifications (iOS and Android)
+- Critical alerts that bypass Do Not Disturb
+- Actionable notifications
+- Group notifications for families
+- Third-party service integrations (Telegram, Discord, etc.)
+- Email notifications
+- Smart speaker announcements
+
+---
+
+## Mobile App Notifications
+
+### Prerequisites
+
+Install and configure the Home Assistant Companion App:
+- **iOS:** [App Store](https://apps.apple.com/app/home-assistant/id1099568401)
+- **Android:** [Google Play](https://play.google.com/store/apps/details?id=io.homeassistant.companion.android)
+
+After setup, you'll have a notify service like `notify.mobile_app_your_phone`.
+
+### Basic Notification
+
+```yaml
+service: notify.mobile_app_your_phone
+data:
+  title: "Emergency Alert"
+  message: >
+    {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+    is {{ states('sensor.abc_emergency_home_nearest_incident') }}km away
+```
+
+### With Entity Picture
+
+Include an image in the notification (requires external image URL):
+
+```yaml
+service: notify.mobile_app_your_phone
+data:
+  title: "Emergency Alert"
+  message: "Active emergency nearby"
+  data:
+    image: "https://www.abc.net.au/emergency/img/icons/fire-icon.png"
+```
+
+### Notification Channel (Android)
+
+Android allows notification channels for different alert types:
+
+```yaml
+service: notify.mobile_app_your_phone
+data:
+  title: "Emergency Alert"
+  message: "Details here"
+  data:
+    channel: emergency_alerts
+    importance: high
+    vibrationPattern: "100, 1000, 100, 1000, 100"
+    ledColor: red
+```
+
+---
+
+## Critical Alerts
+
+Critical alerts bypass Do Not Disturb and silent mode - use them only for genuine emergencies.
+
+### iOS Critical Alerts
+
+```yaml
+service: notify.mobile_app_your_iphone
+data:
+  title: "EMERGENCY WARNING"
+  message: >
+    {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+    is {{ states('sensor.abc_emergency_home_nearest_incident') }}km away!
+  data:
+    push:
+      sound:
+        name: default
+        critical: 1
+        volume: 1.0
+```
+
+**Note:** Critical alerts require enabling in iOS Settings:
+1. Settings → Notifications → Home Assistant
+2. Enable "Critical Alerts"
+
+### Android High Priority
+
+```yaml
+service: notify.mobile_app_your_android
+data:
+  title: "EMERGENCY WARNING"
+  message: >
+    {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+    is {{ states('sensor.abc_emergency_home_nearest_incident') }}km away!
+  data:
+    ttl: 0
+    priority: high
+    channel: alarm_stream
+```
+
+### Time-Sensitive Notifications (iOS 15+)
+
+```yaml
+service: notify.mobile_app_your_iphone
+data:
+  title: "WATCH AND ACT"
+  message: "Take action now"
+  data:
+    push:
+      interruption-level: time-sensitive
+```
+
+Interruption levels:
+- `passive` - Silent delivery
+- `active` - Default behavior
+- `time-sensitive` - Breaks through Focus
+- `critical` - Bypasses all settings (requires permission)
+
+---
+
+## Actionable Notifications
+
+Add buttons to notifications for quick actions.
+
+### iOS Actionable Notification
+
+First, configure actions in your `configuration.yaml`:
+
+```yaml
+ios:
+  push:
+    categories:
+      - name: Emergency Alert
+        identifier: 'emergency_alert'
+        actions:
+          - identifier: 'VIEW_MAP'
+            title: 'View Map'
+            activationMode: 'foreground'
+          - identifier: 'MARK_SAFE'
+            title: 'Mark as Safe'
+            activationMode: 'background'
+          - identifier: 'CALL_000'
+            title: 'Call 000'
+            activationMode: 'foreground'
+            destructive: true
+```
+
+Then send the notification:
+
+```yaml
+service: notify.mobile_app_your_iphone
+data:
+  title: "Emergency Warning"
+  message: "Bushfire nearby"
+  data:
+    push:
+      category: emergency_alert
+```
+
+Handle the action in an automation:
+
+```yaml
+automation:
+  - id: abc_emergency_notification_action
+    alias: "Handle Emergency Notification Action"
+    trigger:
+      - platform: event
+        event_type: ios.notification_action_fired
+        event_data:
+          actionName: MARK_SAFE
+    action:
+      - service: input_boolean.turn_on
+        target:
+          entity_id: input_boolean.family_safe
+```
+
+### Android Actionable Notification
+
+```yaml
+service: notify.mobile_app_your_android
+data:
+  title: "Emergency Warning"
+  message: "Bushfire nearby"
+  data:
+    actions:
+      - action: "VIEW_MAP"
+        title: "View Map"
+      - action: "MARK_SAFE"
+        title: "Mark as Safe"
+      - action: "URI"
+        title: "ABC Emergency"
+        uri: "https://www.abc.net.au/emergency"
+```
+
+---
+
+## Group Notifications
+
+Send notifications to multiple family members at once.
+
+### Create a Notification Group
+
+In `configuration.yaml`:
+
+```yaml
+notify:
+  - name: family_group
+    platform: group
+    services:
+      - service: mobile_app_mum_iphone
+      - service: mobile_app_dad_android
+      - service: mobile_app_child_phone
+```
+
+### Use the Group
+
+```yaml
+service: notify.family_group
+data:
+  title: "Family Emergency Alert"
+  message: >
+    Emergency near our home!
+    {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+    is {{ states('sensor.abc_emergency_home_nearest_incident') }}km away.
+```
+
+---
+
+## Telegram Integration
+
+Send alerts via Telegram for cross-platform coverage.
+
+### Setup
+
+1. Create a Telegram bot via [@BotFather](https://t.me/botfather)
+2. Get your chat ID
+3. Add to `configuration.yaml`:
+
+```yaml
+telegram_bot:
+  - platform: polling
+    api_key: YOUR_BOT_API_KEY
+    allowed_chat_ids:
+      - YOUR_CHAT_ID
+
+notify:
+  - name: telegram_emergency
+    platform: telegram
+    chat_id: YOUR_CHAT_ID
+```
+
+### Send Alert
+
+```yaml
+service: notify.telegram_emergency
+data:
+  title: "ABC Emergency Alert"
+  message: >
+    *{{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }}*
+
+    {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+
+    📍 Distance: {{ states('sensor.abc_emergency_home_nearest_incident') }}km
+    🧭 Direction: {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'direction') }}
+    ⚠️ Level: {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'alert_level') }}
+
+    [View on ABC Emergency](https://www.abc.net.au/emergency)
+```
+
+### With Inline Buttons
+
+```yaml
+service: telegram_bot.send_message
+data:
+  target: YOUR_CHAT_ID
+  message: "Emergency Alert - Respond with your status"
+  inline_keyboard:
+    - - text: "I'm Safe"
+        callback_data: "/safe"
+      - text: "Need Help"
+        callback_data: "/help"
+```
+
+---
+
+## Discord Integration
+
+Send alerts to a Discord channel or user.
+
+### Setup
+
+1. Create a webhook in your Discord server
+2. Add to `configuration.yaml`:
+
+```yaml
+notify:
+  - name: discord_emergency
+    platform: discord
+    token: YOUR_BOT_TOKEN
+```
+
+### Send Alert
+
+```yaml
+service: notify.discord_emergency
+data:
+  target: YOUR_CHANNEL_ID
+  title: "ABC Emergency Alert"
+  message: >
+    **{{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }}**
+
+    {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+
+    📍 **Distance:** {{ states('sensor.abc_emergency_home_nearest_incident') }}km
+    🧭 **Direction:** {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'direction') }}
+  data:
+    embed:
+      color: 16711680  # Red
+```
+
+---
+
+## Signal Messenger
+
+Using the Signal Messenger integration:
+
+```yaml
+notify:
+  - name: signal_emergency
+    platform: signal_messenger
+    url: "http://localhost:8080"  # signal-cli-rest-api URL
+    number: "+61400000000"
+    recipients:
+      - "+61400111111"
+      - "+61400222222"
+```
+
+```yaml
+service: notify.signal_emergency
+data:
+  message: >
+    🚨 EMERGENCY ALERT
+
+    {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }}:
+    {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+
+    Distance: {{ states('sensor.abc_emergency_home_nearest_incident') }}km
+    Direction: {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'direction') }}
+
+    Check ABC Emergency: https://www.abc.net.au/emergency
+```
+
+---
+
+## Email Notifications
+
+For less urgent updates or digests.
+
+### Setup SMTP
+
+In `configuration.yaml`:
+
+```yaml
+notify:
+  - name: email_emergency
+    platform: smtp
+    server: smtp.gmail.com
+    port: 587
+    sender: your.email@gmail.com
+    username: your.email@gmail.com
+    password: YOUR_APP_PASSWORD
+    recipient:
+      - family@example.com
+    sender_name: Home Assistant Emergency
+```
+
+### Send Email
+
+```yaml
+service: notify.email_emergency
+data:
+  title: "ABC Emergency Alert - {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }}"
+  message: >
+    Emergency Alert
+
+    Type: {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }}
+    Headline: {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+    Distance: {{ states('sensor.abc_emergency_home_nearest_incident') }}km
+    Direction: {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'direction') }}
+    Alert Level: {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'alert_level') }}
+
+    For more information, visit: https://www.abc.net.au/emergency
+
+    --
+    This is an automated message from Home Assistant.
+```
+
+### HTML Email
+
+```yaml
+service: notify.email_emergency
+data:
+  title: "Emergency Alert"
+  message: "See HTML version"
+  data:
+    html: >
+      <h1 style="color: red;">Emergency Alert</h1>
+      <p><strong>{{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }}</strong></p>
+      <p>{{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}</p>
+      <table>
+        <tr><td>Distance:</td><td>{{ states('sensor.abc_emergency_home_nearest_incident') }}km</td></tr>
+        <tr><td>Direction:</td><td>{{ state_attr('sensor.abc_emergency_home_nearest_incident', 'direction') }}</td></tr>
+      </table>
+      <p><a href="https://www.abc.net.au/emergency">View on ABC Emergency</a></p>
+```
+
+---
+
+## Smart Speaker Announcements
+
+### Google Home / Nest
+
+```yaml
+service: tts.google_translate_say
+target:
+  entity_id:
+    - media_player.living_room_speaker
+    - media_player.bedroom_speaker
+data:
+  message: >
+    Attention. Emergency Alert.
+    {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }}
+    detected {{ states('sensor.abc_emergency_home_nearest_incident') }} kilometres
+    to the {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'direction') }}.
+    {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}.
+    Check ABC Emergency for more information.
+```
+
+### Amazon Alexa
+
+Using Alexa Media Player integration:
+
+```yaml
+service: notify.alexa_media
+data:
+  target:
+    - media_player.living_room_echo
+    - media_player.kitchen_echo
+  message: >
+    <voice name="Nicole">
+    <amazon:emotion name="excited" intensity="high">
+    Attention! Emergency Alert!
+    </amazon:emotion>
+    {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }}
+    detected {{ states('sensor.abc_emergency_home_nearest_incident') }} kilometres away.
+    {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}.
+    </voice>
+  data:
+    type: announce
+```
+
+### Apple HomePod
+
+```yaml
+service: tts.cloud_say
+target:
+  entity_id: media_player.homepod
+data:
+  message: >
+    Emergency Alert.
+    {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }}
+    {{ states('sensor.abc_emergency_home_nearest_incident') }} kilometres away.
+  options:
+    voice: en-AU-Standard-A
+```
+
+---
+
+## Notification Templates
+
+### Emergency Levels
+
+Create reusable notification templates using scripts or blueprints.
+
+```yaml
+script:
+  emergency_notify_advice:
+    alias: "Send Advice Level Notification"
+    sequence:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "Emergency Advice"
+          message: >
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+            ({{ states('sensor.abc_emergency_home_nearest_incident') }}km
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'direction') }})
+
+  emergency_notify_watch_and_act:
+    alias: "Send Watch and Act Notification"
+    sequence:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "WATCH AND ACT"
+          message: >
+            Take action now!
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+            is {{ states('sensor.abc_emergency_home_nearest_incident') }}km to the
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'direction') }}
+          data:
+            priority: high
+
+  emergency_notify_emergency_warning:
+    alias: "Send Emergency Warning Notification"
+    sequence:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "EMERGENCY WARNING"
+          message: >
+            ACT IMMEDIATELY!
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+            is {{ states('sensor.abc_emergency_home_nearest_incident') }}km away!
+          data:
+            priority: critical
+            push:
+              sound:
+                critical: 1
+                volume: 1.0
+```
+
+---
+
+## Rate Limiting
+
+Avoid notification spam with conditions and delays.
+
+```yaml
+automation:
+  - id: abc_emergency_rate_limited
+    alias: "ABC Emergency - Rate Limited Notification"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.abc_emergency_home_active_alert
+        to: "on"
+    condition:
+      # Don't send if we've notified in the last 30 minutes
+      - condition: template
+        value_template: >
+          {{ (as_timestamp(now()) - as_timestamp(state_attr('automation.abc_emergency_rate_limited', 'last_triggered'))) > 1800 }}
+    action:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "Emergency Alert"
+          message: "Active emergency nearby"
+```
+
+Or use an input_datetime to track:
+
+```yaml
+input_datetime:
+  last_emergency_notification:
+    name: Last Emergency Notification
+    has_date: true
+    has_time: true
+
+automation:
+  - id: abc_emergency_rate_limited_v2
+    alias: "ABC Emergency - Rate Limited v2"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.abc_emergency_home_active_alert
+        to: "on"
+    condition:
+      - condition: template
+        value_template: >
+          {{ (now() - states('input_datetime.last_emergency_notification') | as_datetime).total_seconds() > 1800 }}
+    action:
+      - service: input_datetime.set_datetime
+        target:
+          entity_id: input_datetime.last_emergency_notification
+        data:
+          datetime: "{{ now().isoformat() }}"
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "Emergency Alert"
+          message: "Active emergency nearby"
+```
+
+---
+
+## Notification Debugging
+
+### Check Notification Service
+
+```yaml
+service: notify.mobile_app_your_phone
+data:
+  title: "Test Notification"
+  message: "If you see this, notifications are working!"
+```
+
+### View Notification History
+
+Check the Home Assistant logs:
+**Settings** → **System** → **Logs**
+
+Search for `notify` or your device name.
+
+### Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| No notifications | Check device is registered in HA Companion App |
+| Delayed notifications | Check phone battery optimization settings |
+| Critical alerts not working | Enable in iOS Settings |
+| Android channels not working | Recreate channel or reinstall app |
+
+---
+
+## Next Steps
+
+- [Automations Guide](automations.md) - Complete automation examples
+- [Scripts Guide](scripts.md) - Emergency scripts and sequences
+- [Troubleshooting](troubleshooting.md) - Common issues and solutions

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -1,0 +1,649 @@
+# Scripts Guide
+
+Ready-to-use Home Assistant scripts for emergency response with ABC Emergency.
+
+Scripts are reusable sequences of actions that can be triggered by automations, buttons, voice commands, or the UI.
+
+---
+
+## Emergency Briefing Script
+
+Get a spoken summary of current emergency conditions.
+
+```yaml
+script:
+  emergency_briefing:
+    alias: "Emergency Briefing"
+    description: "Announce current emergency status"
+    sequence:
+      - choose:
+          # Emergency Warning active
+          - conditions:
+              - condition: state
+                entity_id: binary_sensor.abc_emergency_home_emergency_warning
+                state: "on"
+            sequence:
+              - service: tts.google_translate_say
+                target:
+                  entity_id: media_player.living_room_speaker
+                data:
+                  message: >
+                    Emergency Warning in effect.
+                    {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }}
+                    at {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+                    is {{ states('sensor.abc_emergency_home_nearest_incident') }} kilometres
+                    to the {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'direction') }}.
+                    Total incidents nearby: {{ states('sensor.abc_emergency_home_incidents_nearby') }}.
+                    You may need to act immediately.
+
+          # Watch and Act active
+          - conditions:
+              - condition: state
+                entity_id: binary_sensor.abc_emergency_home_watch_and_act
+                state: "on"
+            sequence:
+              - service: tts.google_translate_say
+                target:
+                  entity_id: media_player.living_room_speaker
+                data:
+                  message: >
+                    Watch and Act warning in effect.
+                    {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }}
+                    is {{ states('sensor.abc_emergency_home_nearest_incident') }} kilometres away.
+                    Stay alert and prepare to take action.
+                    Total incidents nearby: {{ states('sensor.abc_emergency_home_incidents_nearby') }}.
+
+          # Advice active
+          - conditions:
+              - condition: state
+                entity_id: binary_sensor.abc_emergency_home_advice
+                state: "on"
+            sequence:
+              - service: tts.google_translate_say
+                target:
+                  entity_id: media_player.living_room_speaker
+                data:
+                  message: >
+                    Emergency Advice in effect.
+                    {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }}
+                    is {{ states('sensor.abc_emergency_home_nearest_incident') }} kilometres away.
+                    Stay informed and monitor conditions.
+
+        # No active alerts
+        default:
+          - service: tts.google_translate_say
+            target:
+              entity_id: media_player.living_room_speaker
+            data:
+              message: >
+                No active emergencies near your location.
+                {{ states('sensor.abc_emergency_nsw_incidents_total') }} incidents are
+                currently active across New South Wales.
+```
+
+---
+
+## Evacuation Checklist Trigger
+
+Activate a checklist and notification sequence when evacuation might be needed.
+
+```yaml
+script:
+  evacuation_checklist:
+    alias: "Evacuation Checklist"
+    description: "Trigger evacuation preparation checklist"
+    sequence:
+      # Turn on bright lights throughout the house
+      - service: light.turn_on
+        target:
+          entity_id:
+            - light.living_room
+            - light.bedroom
+            - light.hallway
+            - light.garage
+        data:
+          brightness: 255
+          color_temp_kelvin: 6500
+
+      # Announce the checklist
+      - service: tts.google_translate_say
+        target:
+          entity_id: media_player.living_room_speaker
+        data:
+          message: >
+            Attention. Evacuation may be required.
+            Emergency is {{ states('sensor.abc_emergency_home_nearest_incident') }} kilometres away.
+            Beginning evacuation checklist.
+
+      - delay: "00:00:05"
+
+      # Send detailed checklist to phones
+      - service: notify.family_group
+        data:
+          title: "EVACUATION CHECKLIST"
+          message: |
+            Emergency is {{ states('sensor.abc_emergency_home_nearest_incident') }}km away.
+
+            Immediate actions:
+            [ ] Close all windows and doors
+            [ ] Move cars to driveway, facing out
+            [ ] Fill bathtubs and sinks with water
+            [ ] Locate important documents
+
+            Grab:
+            [ ] Medications
+            [ ] Phone chargers
+            [ ] Cash/cards
+            [ ] Pet supplies
+            [ ] Emergency kit
+
+            Before leaving:
+            [ ] Turn off gas
+            [ ] Unlock gates
+            [ ] Inform neighbors
+          data:
+            priority: high
+
+      - delay: "00:00:02"
+
+      # Announce key items
+      - service: tts.google_translate_say
+        target:
+          entity_id: media_player.living_room_speaker
+        data:
+          message: >
+            Step 1. Close all windows and doors.
+            Step 2. Move cars to driveway, facing out for quick exit.
+            Step 3. Fill bathtubs with water.
+            Step 4. Gather medications, documents, and emergency kit.
+            Step 5. Put pets in carriers.
+            Monitor ABC Emergency for updates.
+```
+
+---
+
+## Family Location Check
+
+Check and announce the status of all family members.
+
+```yaml
+script:
+  family_location_check:
+    alias: "Family Location Check"
+    description: "Check emergency status for all family members"
+    sequence:
+      - service: notify.family_group
+        data:
+          title: "Family Emergency Check"
+          message: |
+            Current emergency status for family:
+
+            🏠 Home: {{ 'ALERT' if is_state('binary_sensor.abc_emergency_home_active_alert', 'on') else 'Clear' }}
+            {% if is_state('binary_sensor.abc_emergency_home_active_alert', 'on') %}
+            Nearest: {{ states('sensor.abc_emergency_home_nearest_incident') }}km
+            {% endif %}
+
+            👨 Dad: {{ 'ALERT' if is_state('binary_sensor.abc_emergency_dad_active_alert', 'on') else 'Clear' }}
+            {% if is_state('binary_sensor.abc_emergency_dad_active_alert', 'on') %}
+            Nearest: {{ states('sensor.abc_emergency_dad_nearest_incident') }}km
+            {% endif %}
+
+            👩 Mum: {{ 'ALERT' if is_state('binary_sensor.abc_emergency_mum_active_alert', 'on') else 'Clear' }}
+            {% if is_state('binary_sensor.abc_emergency_mum_active_alert', 'on') %}
+            Nearest: {{ states('sensor.abc_emergency_mum_nearest_incident') }}km
+            {% endif %}
+
+            Reply with your status.
+```
+
+---
+
+## Emergency Mode Activation
+
+Activate a house-wide "emergency mode" with multiple actions.
+
+```yaml
+script:
+  emergency_mode_on:
+    alias: "Emergency Mode On"
+    description: "Activate emergency mode for the house"
+    sequence:
+      # Set an input boolean to track mode
+      - service: input_boolean.turn_on
+        target:
+          entity_id: input_boolean.emergency_mode
+
+      # Flash exterior lights to alert neighbors
+      - repeat:
+          count: 3
+          sequence:
+            - service: light.turn_on
+              target:
+                entity_id: light.front_porch
+              data:
+                color_name: red
+                brightness: 255
+            - delay: "00:00:01"
+            - service: light.turn_off
+              target:
+                entity_id: light.front_porch
+            - delay: "00:00:01"
+
+      # Leave exterior lights on red
+      - service: light.turn_on
+        target:
+          entity_id:
+            - light.front_porch
+            - light.back_porch
+        data:
+          color_name: red
+          brightness: 255
+
+      # Interior lights bright white
+      - service: light.turn_on
+        target:
+          entity_id:
+            - light.living_room
+            - light.kitchen
+            - light.hallway
+        data:
+          brightness: 255
+          color_temp_kelvin: 6500
+
+      # Turn on all TVs to ABC
+      - service: media_player.turn_on
+        target:
+          entity_id: media_player.living_room_tv
+
+      # Announce
+      - service: tts.google_translate_say
+        target:
+          entity_id: media_player.living_room_speaker
+        data:
+          message: >
+            Emergency mode activated.
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }}
+            detected {{ states('sensor.abc_emergency_home_nearest_incident') }} kilometres away.
+            Check TV for updates.
+
+      # Notify everyone
+      - service: notify.family_group
+        data:
+          title: "EMERGENCY MODE ACTIVATED"
+          message: >
+            Home is now in emergency mode.
+            {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+            is {{ states('sensor.abc_emergency_home_nearest_incident') }}km away.
+          data:
+            priority: critical
+
+  emergency_mode_off:
+    alias: "Emergency Mode Off"
+    description: "Deactivate emergency mode"
+    sequence:
+      - service: input_boolean.turn_off
+        target:
+          entity_id: input_boolean.emergency_mode
+
+      # Restore normal lighting
+      - service: light.turn_on
+        target:
+          entity_id:
+            - light.front_porch
+            - light.back_porch
+        data:
+          color_temp_kelvin: 3000
+          brightness: 128
+
+      - service: scene.turn_on
+        target:
+          entity_id: scene.evening_lighting
+
+      # Announce all clear
+      - service: tts.google_translate_say
+        target:
+          entity_id: media_player.living_room_speaker
+        data:
+          message: >
+            Emergency mode deactivated. Returning to normal operations.
+
+      - service: notify.family_group
+        data:
+          title: "Emergency Mode Off"
+          message: "Home has returned to normal mode. Stay safe."
+```
+
+**Supporting input_boolean:**
+
+```yaml
+input_boolean:
+  emergency_mode:
+    name: Emergency Mode
+    icon: mdi:alert-circle
+```
+
+---
+
+## Fire Danger Day Preparation
+
+Prepare for high fire danger days proactively.
+
+```yaml
+script:
+  fire_danger_prep:
+    alias: "Fire Danger Day Preparation"
+    description: "Prepare for high fire danger conditions"
+    sequence:
+      # Morning announcement
+      - service: tts.google_translate_say
+        target:
+          entity_id: media_player.living_room_speaker
+        data:
+          message: >
+            Good morning. Today is a high fire danger day.
+            Currently {{ states('sensor.abc_emergency_nsw_bushfires') }} bushfires active in New South Wales.
+            Remember to clear gutters, check your bushfire survival plan, and monitor conditions.
+
+      # Send detailed checklist
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "Fire Danger Day Checklist"
+          message: |
+            High fire danger day - preparation checklist:
+
+            Morning tasks:
+            [ ] Check ABC Emergency for current incidents
+            [ ] Clear any debris from gutters
+            [ ] Move flammable items away from house
+            [ ] Connect hoses and fill containers with water
+            [ ] Ensure pets can be quickly secured
+
+            Keep handy:
+            [ ] Car keys and phones
+            [ ] Important documents
+            [ ] Medications
+
+            Know your plan:
+            [ ] Review evacuation routes
+            [ ] Confirm meeting point with family
+            [ ] Know when to leave (don't wait)
+
+      # Set a reminder for evening
+      - service: input_datetime.set_datetime
+        target:
+          entity_id: input_datetime.fire_danger_reminder
+        data:
+          time: "18:00:00"
+```
+
+---
+
+## Emergency Info Summary
+
+Generate a comprehensive emergency summary for sharing.
+
+```yaml
+script:
+  emergency_summary:
+    alias: "Generate Emergency Summary"
+    description: "Create a text summary of current emergency conditions"
+    fields:
+      notify_target:
+        description: "Notification service to send summary to"
+        example: "notify.mobile_app_your_phone"
+    sequence:
+      - service: "{{ notify_target }}"
+        data:
+          title: "Emergency Summary - {{ now().strftime('%H:%M %d/%m') }}"
+          message: |
+            === ABC EMERGENCY SUMMARY ===
+
+            🏠 HOME STATUS
+            {% if is_state('binary_sensor.abc_emergency_home_active_alert', 'on') %}
+            ⚠️ ACTIVE ALERT
+            Nearest: {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+            Distance: {{ states('sensor.abc_emergency_home_nearest_incident') }}km {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'direction') }}
+            Level: {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'alert_level') }}
+            Type: {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'event_type') }}
+            {% else %}
+            ✅ No active alerts near home
+            {% endif %}
+
+            📊 STATE OVERVIEW (NSW)
+            Total Incidents: {{ states('sensor.abc_emergency_nsw_incidents_total') }}
+            Bushfires: {{ states('sensor.abc_emergency_nsw_bushfires') }}
+            Floods: {{ states('sensor.abc_emergency_nsw_floods') }}
+            Storms: {{ states('sensor.abc_emergency_nsw_storms') }}
+            Highest Level: {{ states('sensor.abc_emergency_nsw_highest_alert_level') }}
+
+            🔗 More info: abc.net.au/emergency
+
+            Generated: {{ now().strftime('%Y-%m-%d %H:%M:%S') }}
+```
+
+**Usage:**
+
+```yaml
+service: script.emergency_summary
+data:
+  notify_target: notify.mobile_app_your_phone
+```
+
+---
+
+## Pet Evacuation Reminder
+
+Special reminder for pet owners during emergencies.
+
+```yaml
+script:
+  pet_evacuation_reminder:
+    alias: "Pet Evacuation Reminder"
+    description: "Remind about pet safety during evacuation"
+    sequence:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "PET EVACUATION REMINDER"
+          message: |
+            Don't forget your pets!
+
+            🐕 Dogs:
+            [ ] Leash and collar with ID
+            [ ] Carrier or crate
+            [ ] Food and water bowls
+            [ ] Medications
+
+            🐈 Cats:
+            [ ] Secure carrier
+            [ ] Litter tray and litter
+            [ ] Food
+            [ ] Medications
+
+            🐦 Birds/Small Animals:
+            [ ] Covered cage
+            [ ] Food and water
+            [ ] Towel for warmth
+
+            🐴 Horses/Livestock:
+            [ ] Open gates if you must leave them
+            [ ] Remove rugs and halters if leaving
+            [ ] Photograph and note identifying marks
+
+            Never leave pets in vehicles!
+          data:
+            priority: high
+
+      - service: tts.google_translate_say
+        target:
+          entity_id: media_player.living_room_speaker
+        data:
+          message: >
+            Don't forget your pets during evacuation.
+            Make sure all animals are secured in carriers or on leashes.
+```
+
+---
+
+## Shelter in Place Mode
+
+For situations where evacuation is not possible or advised.
+
+```yaml
+script:
+  shelter_in_place:
+    alias: "Shelter in Place Mode"
+    description: "Activate shelter in place procedures"
+    sequence:
+      - service: input_boolean.turn_on
+        target:
+          entity_id: input_boolean.shelter_in_place
+
+      # Close all blinds/covers
+      - service: cover.close_cover
+        target:
+          entity_id: all
+
+      # Turn on all interior lights
+      - service: light.turn_on
+        target:
+          entity_id: light.all_interior
+        data:
+          brightness: 255
+
+      # Announcement
+      - service: tts.google_translate_say
+        target:
+          entity_id: media_player.living_room_speaker
+        data:
+          message: >
+            Shelter in place mode activated.
+            Close all windows and doors.
+            Block gaps under doors with wet towels.
+            Turn off air conditioning.
+            Move to an interior room away from windows.
+            Monitor ABC Emergency for updates.
+
+      - service: notify.family_group
+        data:
+          title: "SHELTER IN PLACE"
+          message: |
+            Shelter in place mode activated.
+
+            Immediate actions:
+            [ ] Close all windows and doors
+            [ ] Block gaps with wet towels
+            [ ] Turn off A/C and fans
+            [ ] Go to interior room
+
+            Stay away from:
+            - Windows
+            - External walls
+            - Attics
+
+            Monitor ABC Emergency for all-clear.
+          data:
+            priority: critical
+```
+
+---
+
+## Using Scripts in Automations
+
+Trigger scripts from automations:
+
+```yaml
+automation:
+  - id: abc_emergency_trigger_evacuation
+    alias: "Trigger Evacuation Checklist on Emergency"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.abc_emergency_home_emergency_warning
+        to: "on"
+    action:
+      - service: script.evacuation_checklist
+```
+
+---
+
+## Using Scripts with Voice Assistants
+
+### Google Assistant / Alexa
+
+Create a routine that calls your script:
+
+```yaml
+# In configuration.yaml, expose the script:
+homeassistant:
+  customize:
+    script.emergency_briefing:
+      google_assistant_type: script
+      google_assistant_name: Emergency Briefing
+```
+
+Then say: "Hey Google, activate Emergency Briefing"
+
+### With Assist
+
+```yaml
+intent_script:
+  EmergencyBriefing:
+    speech:
+      text: "Getting emergency briefing"
+    action:
+      - service: script.emergency_briefing
+```
+
+---
+
+## Script Dashboard Card
+
+Create a dashboard card with emergency scripts:
+
+```yaml
+type: vertical-stack
+cards:
+  - type: markdown
+    content: |
+      ## Emergency Scripts
+      Tap to activate emergency procedures
+  - type: horizontal-stack
+    cards:
+      - type: button
+        entity: script.emergency_briefing
+        name: Briefing
+        icon: mdi:bullhorn
+        tap_action:
+          action: call-service
+          service: script.emergency_briefing
+      - type: button
+        entity: script.evacuation_checklist
+        name: Evacuate
+        icon: mdi:exit-run
+        tap_action:
+          action: call-service
+          service: script.evacuation_checklist
+  - type: horizontal-stack
+    cards:
+      - type: button
+        entity: script.emergency_mode_on
+        name: Emergency On
+        icon: mdi:alert
+        tap_action:
+          action: call-service
+          service: script.emergency_mode_on
+      - type: button
+        entity: script.emergency_mode_off
+        name: All Clear
+        icon: mdi:check-circle
+        tap_action:
+          action: call-service
+          service: script.emergency_mode_off
+```
+
+---
+
+## Next Steps
+
+- [Automations Guide](automations.md) - Trigger scripts from automations
+- [Notifications Guide](notifications.md) - Notification options
+- [Advanced Usage](advanced.md) - Complex integrations

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,420 @@
+# Troubleshooting Guide
+
+Solutions to common issues with ABC Emergency for Home Assistant.
+
+---
+
+## Installation Issues
+
+### Integration Not Found After Installation
+
+**Symptom:** After installing via HACS, "ABC Emergency" doesn't appear when adding integrations.
+
+**Solutions:**
+
+1. **Restart Home Assistant**
+   - HACS installations require a restart
+   - Settings → System → Restart
+
+2. **Check Installation Location**
+   - The integration should be at `/config/custom_components/abcemergency/`
+   - Verify the folder structure is correct
+
+3. **Check for Errors in Logs**
+   - Settings → System → Logs
+   - Look for errors mentioning `abcemergency`
+
+4. **Clear Browser Cache**
+   - Sometimes the integration list is cached
+   - Hard refresh (Ctrl+F5) or clear browser cache
+
+### HACS Not Showing the Integration
+
+**Symptom:** Can't find ABC Emergency in HACS even after adding as custom repository.
+
+**Solutions:**
+
+1. **Verify Custom Repository URL**
+   - URL should be: `https://github.com/troykelly/homeassistant-abcemergency`
+   - Category should be: Integration
+
+2. **Refresh HACS**
+   - HACS → Integrations → Three dots menu → Reload
+
+3. **Check HACS Logs**
+   - HACS has its own log accessible from its menu
+   - Look for errors fetching the repository
+
+---
+
+## Configuration Issues
+
+### Can't Select Location on Map
+
+**Symptom:** The map picker doesn't respond or location can't be set.
+
+**Solutions:**
+
+1. **Check Browser Console**
+   - Press F12 → Console tab
+   - Look for JavaScript errors
+
+2. **Try Manual Coordinates**
+   - You can enter latitude/longitude directly
+   - Use Google Maps to find coordinates
+
+3. **Different Browser**
+   - Try a different browser (Chrome, Firefox, Safari)
+   - Some map features have browser-specific issues
+
+### Person Entity Not Appearing
+
+**Symptom:** When setting up Person Mode, no person entities appear in the dropdown.
+
+**Solutions:**
+
+1. **Verify Person Has Location**
+   - Developer Tools → States
+   - Search for `person.`
+   - Check that your person has `latitude` and `longitude` attributes
+
+2. **Assign Device Tracker to Person**
+   - Settings → People → Select person
+   - Add device trackers under "Devices"
+
+3. **Verify Device Tracker is Updating**
+   - The device tracker must be reporting GPS coordinates
+   - Check the Companion App settings on the mobile device
+
+---
+
+## Entity Issues
+
+### Entities Show "Unknown" or "Unavailable"
+
+**Symptom:** Sensors show `unknown` or `unavailable` instead of values.
+
+**Solutions:**
+
+1. **Wait for First Update**
+   - After setup, data takes up to 5 minutes to populate
+   - Check back after the first refresh cycle
+
+2. **Check API Connectivity**
+   - Developer Tools → Services
+   - Call `homeassistant.update_entity` on any ABC Emergency sensor
+   - Check logs for API errors
+
+3. **Verify Internet Connectivity**
+   - The integration requires internet access to `www.abc.net.au`
+   - Check if the ABC Emergency website is accessible
+
+4. **Check for API Changes**
+   - Occasionally the ABC Emergency API may change
+   - Check the GitHub repository for known issues
+
+### Nearest Incident Shows Wrong Distance
+
+**Symptom:** The distance to nearest incident seems incorrect.
+
+**Solutions:**
+
+1. **Verify Configured Location**
+   - Go to Settings → Devices & Services → ABC Emergency
+   - Check that latitude/longitude are correct
+
+2. **Check Person Entity Location**
+   - For Person Mode, verify the person entity's coordinates
+   - Developer Tools → States → Search for your person
+
+3. **Understand Distance Calculation**
+   - Distance is calculated as-the-crow-flies (not road distance)
+   - Large incidents may have centroids far from their edges
+
+### Binary Sensors Not Triggering
+
+**Symptom:** Automations based on binary sensors don't fire.
+
+**Solutions:**
+
+1. **Check Binary Sensor States**
+   - Developer Tools → States
+   - Search for `binary_sensor.abc_emergency_`
+   - Verify the sensor transitions from `off` to `on`
+
+2. **Verify Alert Level**
+   - Binary sensors only turn on for nearby incidents (Zone/Person mode)
+   - State mode uses state-wide alerts
+
+3. **Test with Lower Thresholds**
+   - Temporarily increase your alert radii
+   - This can help determine if it's a threshold issue
+
+---
+
+## API and Connectivity
+
+### "Unable to Fetch Data" Error
+
+**Symptom:** Error in logs about failing to fetch emergency data.
+
+**Solutions:**
+
+1. **Check ABC Emergency Website**
+   - Visit https://www.abc.net.au/emergency
+   - If the website is down, the API won't work
+
+2. **Check Network Connectivity**
+   - Verify Home Assistant can reach external websites
+   - Try `ping www.abc.net.au` from the host machine
+
+3. **Check for Firewall/Proxy Issues**
+   - Some networks block certain domains
+   - Verify outbound HTTPS (port 443) is allowed
+
+### Rate Limiting
+
+**Symptom:** Occasional errors or delays in data updates.
+
+**Solutions:**
+
+The ABC Emergency API doesn't appear to have strict rate limits, but:
+
+1. **Don't Lower Update Interval**
+   - The 5-minute interval is appropriate
+   - More frequent polling won't be more effective
+
+2. **Check for Multiple Instances**
+   - Many instances will multiply API calls
+   - Consider consolidating if you have many
+
+---
+
+## Automation Issues
+
+### Automations Not Triggering
+
+**Symptom:** Automations using ABC Emergency entities don't run.
+
+**Solutions:**
+
+1. **Check Automation is Enabled**
+   - Settings → Automations & Scenes
+   - Ensure the automation toggle is on
+
+2. **Trace the Automation**
+   - Open the automation → Three dots → Traces
+   - See why it didn't trigger
+
+3. **Verify Entity Names**
+   - Entity IDs must match exactly
+   - Check for typos in entity names
+
+4. **Test Trigger Conditions**
+   - Manually check if conditions would be true
+   - Use Developer Tools → Template to test
+
+### Template Errors in Notifications
+
+**Symptom:** Notifications show template text instead of values, or error messages.
+
+**Solutions:**
+
+1. **Check Template Syntax**
+   - Jinja2 templates are sensitive to syntax
+   - Use Developer Tools → Template to test
+
+2. **Handle Missing Attributes**
+   - Attributes may not exist when no incidents are present
+   - Use default filters: `{{ state_attr('sensor...', 'headline') | default('No incident') }}`
+
+3. **Check Entity State**
+   - If sensor is `unknown`, attributes won't exist
+   - Add conditions to check sensor availability
+
+**Example with error handling:**
+
+```yaml
+message: >
+  {% if states('sensor.abc_emergency_home_nearest_incident') not in ['unknown', 'unavailable'] %}
+    {{ state_attr('sensor.abc_emergency_home_nearest_incident', 'headline') }}
+    is {{ states('sensor.abc_emergency_home_nearest_incident') }}km away
+  {% else %}
+    No active incidents
+  {% endif %}
+```
+
+---
+
+## Performance Issues
+
+### Slow Dashboard Loading
+
+**Symptom:** Dashboards with ABC Emergency entities load slowly.
+
+**Solutions:**
+
+1. **Limit Map Entities**
+   - Geo-location entities can be numerous
+   - Consider filtering by distance in custom cards
+
+2. **Use History Exclusions**
+   - Exclude ABC Emergency entities from history if not needed:
+   ```yaml
+   recorder:
+     exclude:
+       entity_globs:
+         - geo_location.abc_emergency_*
+   ```
+
+### High Memory Usage
+
+**Symptom:** Home Assistant memory usage increases over time.
+
+**Solutions:**
+
+1. **Check for Many Instances**
+   - Each instance maintains its own data
+   - Reduce instances if memory is limited
+
+2. **Restart Periodically**
+   - Schedule regular Home Assistant restarts if needed
+   - This clears any accumulated memory
+
+---
+
+## Debug Logging
+
+### Enable Debug Logs
+
+To see detailed logs for troubleshooting:
+
+```yaml
+# In configuration.yaml
+logger:
+  default: warning
+  logs:
+    custom_components.abcemergency: debug
+```
+
+After adding, restart Home Assistant.
+
+### View Logs
+
+1. **Via UI**
+   - Settings → System → Logs
+   - Filter by "abcemergency"
+
+2. **Via File**
+   - `/config/home-assistant.log`
+   - Search for "abcemergency"
+
+### What to Look For
+
+| Log Pattern | Meaning |
+|-------------|---------|
+| `Fetching emergency data for...` | Normal update cycle |
+| `Found X emergencies` | Successful data fetch |
+| `Error fetching data` | API or network issue |
+| `Coordinator update failed` | Update cycle problem |
+
+---
+
+## Diagnostic Information
+
+### Download Diagnostics
+
+1. Settings → Devices & Services → ABC Emergency
+2. Click on your instance
+3. Click "Download Diagnostics"
+
+This file contains:
+- Configuration (sensitive data redacted)
+- Current sensor states
+- Cached incident data
+- Last update timestamp
+
+**Include this when reporting issues.**
+
+---
+
+## Common Error Messages
+
+### "Authentication failed"
+
+This shouldn't occur as the API is public. If you see this:
+- Clear the integration and re-add
+- Check for network proxy issues
+
+### "Connection timeout"
+
+- Check internet connectivity
+- ABC Emergency website may be temporarily unavailable
+- Check for DNS issues
+
+### "Unexpected response format"
+
+- The API may have changed
+- Check GitHub issues for reports
+- Wait for an integration update
+
+---
+
+## Reporting Issues
+
+If you can't resolve an issue:
+
+1. **Search Existing Issues**
+   - https://github.com/troykelly/homeassistant-abcemergency/issues
+
+2. **Gather Information**
+   - Home Assistant version
+   - Integration version
+   - Debug logs
+   - Diagnostics download
+   - Steps to reproduce
+
+3. **Create New Issue**
+   - Use the Bug Report template
+   - Include all gathered information
+
+---
+
+## FAQ
+
+### Q: Why is data only updated every 5 minutes?
+
+The 5-minute interval balances:
+- Timely emergency information
+- Responsible use of the ABC Emergency service
+- Typical update frequency of source data
+
+Emergency data at the source typically updates every few minutes, so more frequent polling wouldn't provide significantly fresher data.
+
+### Q: Can I change the update interval?
+
+No, the update interval is fixed at 5 minutes to ensure consistent, responsible behavior across all installations.
+
+### Q: Why are there no incidents showing?
+
+During calm periods, there may be few or no emergency incidents. Check the ABC Emergency website to verify current activity in your area.
+
+### Q: Does this work outside Australia?
+
+No. The ABC Emergency service only covers Australia. The integration requires Australian coordinates to be configured.
+
+### Q: Is my data sent anywhere?
+
+No. The integration only:
+- Fetches public data from ABC Emergency
+- Processes it locally in your Home Assistant
+- No data is sent from your system
+
+---
+
+## Next Steps
+
+- [Getting Started](getting-started.md) - Initial setup guide
+- [Configuration](configuration.md) - Configuration options
+- [Entities Reference](entities.md) - Entity documentation
+- [GitHub Issues](https://github.com/troykelly/homeassistant-abcemergency/issues) - Report bugs


### PR DESCRIPTION
## Summary

Creates a comprehensive documentation suite for the ABC Emergency for Home Assistant integration, designed as a professional, user-friendly landing page and documentation set.

Fixes #29

## Changes

### README.md (Landing Page)
- SaaS-style hero section with key value proposition
- Feature highlights above the fold
- Australian Warning System explanation with levels
- Quick start installation guide (3 steps)
- Example automations for tiered notifications
- Clear, prominent disclaimer about ABC non-affiliation
- Acknowledgment of Country (Gadigal and Wangal peoples of the Eora Nation)
- Story behind the integration (created December 2025 during Woy Woy bushfires)

### Documentation Suite
| Document | Purpose |
|----------|---------|
| `docs/getting-started.md` | Installation (HACS/manual) and first-time setup |
| `docs/configuration.md` | All configuration options (State/Zone/Person modes) |
| `docs/entities.md` | Complete sensor and binary sensor reference with attributes |
| `docs/automations.md` | Ready-to-use automation examples (tiered alerts, distance, TTS, lights) |
| `docs/notifications.md` | Mobile, critical alerts, Telegram, Discord, email, TTS |
| `docs/scripts.md` | Emergency scripts (briefing, evacuation checklist, family check) |
| `docs/troubleshooting.md` | Common issues, debug logging, FAQ |
| `docs/advanced.md` | Template sensors, Node-RED, AppDaemon, REST API |

## Testing

All automation and script examples were:
- ✅ Written to test files (`config/automations.yaml`, `config/scripts.yaml`)
- ✅ Validated for YAML syntax
- ✅ Loaded into local dev Home Assistant
- ✅ Verified entity IDs match actual integration entities

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify all documentation links work
- [ ] Test installation guide steps on fresh install
- [ ] Confirm automation examples work with real entity names

🤖 Generated with [Claude Code](https://claude.com/claude-code)