### PR TITLE
refactor(api): Replace type: ignore with explicit cast() calls

### DIFF
--- a/custom_components/abcemergency/api.py
+++ b/custom_components/abcemergency/api.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from urllib.parse import urlencode
 
 from aiohttp import ClientError, ClientResponseError, ClientTimeout
@@ -142,7 +142,7 @@ class ABCEmergencyClient:
             params={"state": state.lower()},
         )
 
-        return result  # type: ignore[return-value]
+        return cast(EmergencySearchResponse, result)
 
     async def async_get_emergencies_by_geohash(
         self,
@@ -174,7 +174,7 @@ class ABCEmergencyClient:
             params={"geohashes": geohash_param},
         )
 
-        return result  # type: ignore[return-value]
+        return cast(EmergencySearchResponse, result)
 
     async def async_get_all_emergencies(self) -> EmergencyFeedResponse:
         """Fetch all emergencies across Australia.
@@ -193,4 +193,4 @@ class ABCEmergencyClient:
 
         result = await self._async_request("emergencyFeed")
 
-        return result  # type: ignore[return-value]
+        return cast(EmergencyFeedResponse, result)


### PR DESCRIPTION
## Summary
- Replace `type: ignore[return-value]` comments with explicit `cast()` calls in api.py
- This makes intentional type narrowing explicit and improves code documentation
- Allows mypy to verify the cast destination type is valid

## Changes
- Import `cast` from typing module
- Replace 3 instances of `type: ignore[return-value]` with `cast()`:
  - `async_get_emergencies_by_state()` returns `cast(EmergencySearchResponse, result)`
  - `async_get_emergencies_by_geohash()` returns `cast(EmergencySearchResponse, result)`
  - `async_get_all_emergencies()` returns `cast(EmergencyFeedResponse, result)`

## Test plan
- [x] All existing API tests pass (17 tests)
- [x] mypy type checking passes with no issues
- [x] Behavior unchanged - this is purely a type annotation improvement

Fixes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)