### PR TITLE
refactor(config_flow): Improve exception handling specificity

### DIFF
--- a/custom_components/abcemergency/config_flow.py
+++ b/custom_components/abcemergency/config_flow.py
@@ -152,7 +152,7 @@ class ABCEmergencyConfigFlow(ConfigFlow, domain=DOMAIN):
             except ABCEmergencyConnectionError:
                 errors["base"] = "cannot_connect"
             except ABCEmergencyAPIError:
-                errors["base"] = "cannot_connect"
+                errors["base"] = "api_error"
             except Exception:
                 _LOGGER.exception("Unexpected error during API test")
                 errors["base"] = "unknown"

--- a/custom_components/abcemergency/strings.json
+++ b/custom_components/abcemergency/strings.json
@@ -59,7 +59,8 @@
     },
     "error": {
       "cannot_connect": "Failed to connect to ABC Emergency API",
-      "unknown": "Unexpected error occurred",
+      "api_error": "ABC Emergency API returned an error. Please try again later.",
+      "unknown": "Unexpected error occurred. Check logs for details.",
       "name_required": "Please enter a zone name",
       "person_required": "Please select a person entity"
     },

--- a/custom_components/abcemergency/translations/en.json
+++ b/custom_components/abcemergency/translations/en.json
@@ -59,7 +59,8 @@
     },
     "error": {
       "cannot_connect": "Failed to connect to ABC Emergency API",
-      "unknown": "Unexpected error occurred",
+      "api_error": "ABC Emergency API returned an error. Please try again later.",
+      "unknown": "Unexpected error occurred. Check logs for details.",
       "name_required": "Please enter a zone name",
       "person_required": "Please select a person entity"
     },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -228,7 +228,7 @@ class TestConfigFlowStateStep:
             )
 
             assert result["type"] is FlowResultType.FORM
-            assert result["errors"] == {"base": "cannot_connect"}
+            assert result["errors"] == {"base": "api_error"}
 
     async def test_unexpected_error_shows_unknown(
         self,


### PR DESCRIPTION
## Summary
- Distinguish between network connection errors and API errors
- Provides clearer feedback to users during configuration

## Changes
- `ABCEmergencyConnectionError` → "cannot_connect" (unchanged)
- `ABCEmergencyAPIError` → "api_error" (was "cannot_connect")
- Updated error message for "unknown" to mention checking logs
- Added "api_error" string to strings.json and translations/en.json
- Updated test expectations

## User Experience
Users now see distinct error messages:
- **cannot_connect**: "Failed to connect to ABC Emergency API"
- **api_error**: "ABC Emergency API returned an error. Please try again later."
- **unknown**: "Unexpected error occurred. Check logs for details."

## Test plan
- [x] All 23 config_flow tests pass
- [x] Test explicitly verifies API errors show "api_error"

Fixes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)