### PR TITLE
feat(coordinator): Add containment detection to coordinator

### DIFF
--- a/custom_components/abcemergency/models.py
+++ b/custom_components/abcemergency/models.py
@@ -73,6 +73,7 @@ class EmergencyIncident:
     geometry_type: str | None = None
     polygons: list[StoredPolygon] | None = None
     has_polygon: bool = False
+    contains_point: bool | None = None
 
 
 @dataclass
@@ -93,6 +94,12 @@ class CoordinatorData:
         location_available: Whether location is available (for person mode).
         current_latitude: Current latitude used for calculations.
         current_longitude: Current longitude used for calculations.
+        containing_incidents: List of incidents whose polygons contain the monitored point.
+        inside_polygon: True if monitored point is inside any incident polygon.
+        inside_emergency_warning: True if inside polygon with extreme alert level.
+        inside_watch_and_act: True if inside polygon with severe or higher alert level.
+        inside_advice: True if inside polygon with moderate or higher alert level.
+        highest_containing_alert_level: Highest alert level among containing incidents.
     """
 
     incidents: list[EmergencyIncident] = field(default_factory=list)
@@ -106,3 +113,9 @@ class CoordinatorData:
     location_available: bool = True
     current_latitude: float | None = None
     current_longitude: float | None = None
+    containing_incidents: list[EmergencyIncident] = field(default_factory=list)
+    inside_polygon: bool = False
+    inside_emergency_warning: bool = False
+    inside_watch_and_act: bool = False
+    inside_advice: bool = False
+    highest_containing_alert_level: str = ""


### PR DESCRIPTION
## Summary
- Implements point-in-polygon containment detection in the coordinator
- Adds `contains_point` field to `EmergencyIncident` model
- Adds containment summary fields to `CoordinatorData`: `containing_incidents`, `inside_polygon`, `inside_emergency_warning`, `inside_watch_and_act`, `inside_advice`, `highest_containing_alert_level`
- **CRITICAL**: Checks containment for ALL incidents BEFORE radius filtering to ensure large polygons whose centroid is far but still contain the monitored point are properly detected (addresses issue #73)

## Test plan
- [x] Unit tests for `contains_point` field on `EmergencyIncident`
- [x] Unit tests for containment summary fields on `CoordinatorData`
- [x] Tests for point inside polygon detection
- [x] Tests for point outside polygon detection
- [x] Tests for far centroid but containing polygon (issue #73 critical case)
- [x] Tests for state mode (no containment, no monitored point)
- [x] Tests for person mode with containment
- [x] Tests for Point geometry (no containment possible)
- [x] Tests for empty incidents list
- [x] All 372 tests pass with 100% coverage
- [x] mypy passes
- [x] ruff passes

Fixes #63
Fixes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)