### PR TITLE
feat(binary_sensor): Add containment binary sensors

### DIFF
--- a/custom_components/abcemergency/coordinator.py
+++ b/custom_components/abcemergency/coordinator.py
@@ -158,6 +158,15 @@ class ABCEmergencyCoordinator(DataUpdateCoordinator[CoordinatorData]):
             f"{STORAGE_KEY_PREFIX}_{entry.entry_id}",
         )
 
+    @property
+    def instance_type(self) -> Literal["state", "zone", "person"]:
+        """Return the instance type.
+
+        Returns:
+            The instance type (state, zone, or person).
+        """
+        return self._instance_type
+
     def _load_radii(self) -> dict[str, int]:
         """Load radius configuration from entry data/options."""
 

--- a/custom_components/abcemergency/strings.json
+++ b/custom_components/abcemergency/strings.json
@@ -127,6 +127,18 @@
       },
       "advice": {
         "name": "Advice"
+      },
+      "inside_polygon": {
+        "name": "Inside Emergency Polygon"
+      },
+      "inside_emergency_warning": {
+        "name": "Inside Emergency Warning Zone"
+      },
+      "inside_watch_and_act": {
+        "name": "Inside Watch and Act Zone"
+      },
+      "inside_advice": {
+        "name": "Inside Advice Zone"
       }
     }
   }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -267,6 +267,7 @@ class TestCoordinatorInitState:
         )
 
         assert coordinator._instance_type == INSTANCE_TYPE_STATE
+        assert coordinator.instance_type == INSTANCE_TYPE_STATE
         assert coordinator._state == "nsw"
         assert coordinator._latitude is None
         assert coordinator._longitude is None


### PR DESCRIPTION
## Summary

- Add four new binary sensors for zone/person instances to detect when the monitored location is inside emergency incident polygons
- `inside_polygon`: True when location is inside ANY emergency polygon
- `inside_emergency_warning`: True when inside an Emergency Warning zone
- `inside_watch_and_act`: True when inside Watch and Act or higher zone
- `inside_advice`: True when inside any Advice or higher zone
- Each sensor includes attributes with count and details of matching incidents
- Add `instance_type` property to coordinator for external access

## Test Plan

- [x] Unit tests for all containment binary sensor descriptions
- [x] Tests for is_on functions with various containment states
- [x] Tests for attribute functions including filtering by alert level
- [x] Tests verify sensors only created for zone/person instances (not state)
- [x] Full test suite passes with 100% coverage
- [x] mypy passes
- [x] ruff passes

Fixes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)