### PR TITLE
perf(geo): Cache Shapely prepared geometries (#74)

### DIFF
--- a/custom_components/abcemergency/coordinator.py
+++ b/custom_components/abcemergency/coordinator.py
@@ -62,7 +62,7 @@ from .helpers import (
     get_bearing,
     get_state_from_coordinates,
 )
-from .helpers_geo import point_in_polygons
+from .helpers_geo import point_in_incident
 from .models import Coordinate, CoordinatorData, EmergencyIncident
 
 if TYPE_CHECKING:
@@ -437,7 +437,8 @@ class ABCEmergencyCoordinator(DataUpdateCoordinator[CoordinatorData]):
         containing_incidents: list[EmergencyIncident] = []
         for incident in all_incidents:
             if incident.has_polygon:
-                contains = point_in_polygons(latitude, longitude, incident.polygons)
+                # Use cached prepared geometries for efficient containment check
+                contains = point_in_incident(latitude, longitude, incident)
                 # Use object.__setattr__ to modify frozen-like dataclass field
                 object.__setattr__(incident, "contains_point", contains)
                 if contains:

--- a/custom_components/abcemergency/models.py
+++ b/custom_components/abcemergency/models.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .const import StoredPolygon
@@ -74,6 +74,8 @@ class EmergencyIncident:
     polygons: list[StoredPolygon] | None = None
     has_polygon: bool = False
     contains_point: bool | None = None
+    # Cache for prepared Shapely geometries (not serializable, excluded from repr)
+    _prepared_polygons: list[Any] | None = field(default=None, repr=False, compare=False)
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Add lazy caching of prepared Shapely geometries on EmergencyIncident objects to improve performance when checking multiple points against the same incident polygons.

### Changes

- Add `_prepared_polygons` cache field to `EmergencyIncident` dataclass
- Add `_build_prepared_polygons()` to create prepared geometries
- Add `get_prepared_polygons()` for lazy caching
- Add `point_in_incident()` using cached prepared geometries
- Update coordinator to use `point_in_incident()` instead of `point_in_polygons()`
- Add comprehensive tests for caching behavior

### Why Prepared Geometries?

Prepared geometries provide significant speedup for repeated point-in-polygon checks by pre-computing spatial indexes on the polygon. This is especially beneficial when:
- The same incident is checked against multiple points (person tracking)
- Refresh cycles keep the same incidents in memory

Fixes #74

## Test plan

- [x] All existing tests pass (440 tests)
- [x] New tests verify caching behavior works correctly
- [x] Type checker passes
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)