### PR TITLE
feat(events): Add containment severity change event and state-based tracking

### DIFF
--- a/custom_components/abcemergency/const.py
+++ b/custom_components/abcemergency/const.py
@@ -501,3 +501,24 @@ class StoredGeometry(TypedDict):
 
     type: Literal["Point", "Polygon", "MultiPolygon"]
     polygons: list[StoredPolygon] | None
+
+
+# Containment tracking TypedDicts for polygon enter/exit events
+
+
+class ContainmentState(TypedDict):
+    """Previous containment state for an incident.
+
+    Tracks the actual containment relationship between a monitored point
+    and an incident polygon, not just the incident ID. This enables
+    detection of polygon boundary changes and severity escalations.
+
+    Attributes:
+        was_containing: Whether the incident polygon contained the point.
+        alert_level: The alert level of the incident (extreme, severe, moderate, minor).
+        alert_text: Human-readable alert text (Emergency, Watch and Act, Advice, "").
+    """
+
+    was_containing: bool
+    alert_level: str
+    alert_text: str


### PR DESCRIPTION
## Summary

This epic refactors the containment event system to track actual containment state rather than just incident IDs. This enables detection of:

- **Polygon expansion** - incident exists but wasn't containing → now containing
- **Polygon contraction** - incident was containing → still exists but not containing  
- **Severity escalation/de-escalation** - alert level changes while inside polygon

## Changes

### Core Implementation

- **ContainmentState TypedDict** (`const.py`): New type to track per-incident containment state including `was_containing`, `alert_level`, and `alert_text`

- **Refactored containment tracking** (`coordinator.py`):
  - Replace `_previously_containing_ids: set[str]` with `_previous_containment_state: dict[str, ContainmentState]`
  - Track containment state for ALL incidents, not just those currently containing
  - Fire entered events when polygon expands to contain point
  - Fire exited events when polygon shrinks to no longer contain point

- **New severity change event** (`coordinator.py`):
  - `abc_emergency_containment_severity_changed` event fires when alert level changes while inside a polygon
  - Includes `previous_alert_level`, `new_alert_level`, and `escalated` flag
  - Enables automations to respond to Advice→Emergency escalation

### Tests

- 12 new comprehensive test cases in `TestContainmentEventEdgeCases`:
  - Polygon expansion/contraction scenarios
  - Severity escalation/de-escalation
  - Combined scenarios (expansion + severity change)
  - Event data structure validation
  - All alert level transitions

### Documentation

- Updated `docs/automations.md`:
  - New "Severity Escalation Alert" section with example automations
  - Updated Event Reference table with new event
  - Added severity-specific event data fields documentation
  - Example of comprehensive containment handler automation

## Test Plan

- [ ] Run full test suite: `pytest tests/` (462 tests passing)
- [ ] Type checking: `mypy custom_components/abcemergency/` (passes)
- [ ] Linting: `ruff check` and `ruff format` (passes)
- [ ] Coverage at 99.76% (3 defensive guard lines uncovered)

## Closes

- #90 - Parent issue: Containment events don't fire for polygon changes
- #91 - Refactor containment tracking to use actual containment state
- #92 - Add containment severity change event
- #93 - Add comprehensive tests for containment edge cases
- #94 - Update documentation for containment events
- #95 - Epic issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)