### PR TITLE
docs(examples): Add dashboard YAML examples for emergency map display

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,57 @@
+# ABC Emergency Dashboard Examples
+
+This directory contains example Lovelace dashboard configurations for displaying ABC Emergency incidents.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `dashboard_emergency_map.yaml` | Complete dashboard with 4 views: Map, Overview, Bushfires, All Incidents |
+| `cards/map_card.yaml` | Simple map card for embedding in any dashboard |
+| `cards/alert_status_card.yaml` | Color-coded alert status tiles with status message |
+| `cards/incident_summary_card.yaml` | Entity list showing incident counts |
+
+## Usage
+
+### Full Dashboard
+
+1. Copy `dashboard_emergency_map.yaml` to your Home Assistant config directory
+2. Add to your `configuration.yaml`:
+
+```yaml
+lovelace:
+  mode: storage
+  dashboards:
+    emergency:
+      mode: yaml
+      title: Emergency
+      icon: mdi:alert
+      show_in_sidebar: true
+      filename: dashboard_emergency_map.yaml
+```
+
+3. Restart Home Assistant
+
+### Individual Cards
+
+Copy the YAML from any card file and paste it into your Lovelace dashboard using the "Manual" card option in the UI editor.
+
+## Configuration
+
+All examples use placeholder entity names. You must update them to match your installation:
+
+1. **Entity names**: Replace `treehouse` with your zone name (lowercase, underscores for spaces)
+   - Example: `sensor.abc_emergency_treehouse_bushfires` -> `sensor.abc_emergency_sydney_bushfires`
+
+2. **Map source**: Replace `ABC Emergency (Treehouse)` with your config entry title
+   - Find this in Settings > Devices & Services > ABC Emergency
+   - Example: `ABC Emergency (Sydney)`, `ABC Emergency (Melbourne)`
+
+## Views
+
+The full dashboard includes:
+
+- **Map**: Full-screen interactive map showing all incidents as markers
+- **Overview**: Dashboard with embedded map, alert tiles, and incident summary
+- **Bushfires**: Focused view with map and bushfire incident table
+- **All Incidents**: Scrollable list of all nearby incidents with details

--- a/examples/cards/alert_status_card.yaml
+++ b/examples/cards/alert_status_card.yaml
@@ -1,0 +1,50 @@
+# Alert Status Card for ABC Emergency
+#
+# Displays the current alert level with color-coded tiles.
+# Shows emergency warning (red), watch and act (orange), or advice (yellow).
+#
+# Replace "treehouse" with your zone name (lowercase, underscores for spaces)
+
+type: vertical-stack
+title: Alert Status
+cards:
+  - type: horizontal-stack
+    cards:
+      - type: tile
+        entity: binary_sensor.abc_emergency_treehouse_emergency_warning
+        name: Emergency
+        icon: mdi:alert-octagon
+        color: red
+
+      - type: tile
+        entity: binary_sensor.abc_emergency_treehouse_watch_and_act
+        name: Watch & Act
+        icon: mdi:alert
+        color: orange
+
+      - type: tile
+        entity: binary_sensor.abc_emergency_treehouse_advice
+        name: Advice
+        icon: mdi:information
+        color: amber
+
+  - type: markdown
+    content: |
+      {% set sensor = 'sensor.abc_emergency_treehouse_nearest_incident' %}
+      {% if is_state('binary_sensor.abc_emergency_treehouse_emergency_warning', 'on') %}
+      ## EMERGENCY WARNING
+      **Immediate action required!**
+      {% elif is_state('binary_sensor.abc_emergency_treehouse_watch_and_act', 'on') %}
+      ## WATCH AND ACT
+      **Conditions are changing. Be ready to act.**
+      {% elif is_state('binary_sensor.abc_emergency_treehouse_advice', 'on') %}
+      ## ADVICE
+      **An incident has started. Stay informed.**
+      {% else %}
+      ## ALL CLEAR
+      No active alerts in your monitored area.
+      {% endif %}
+
+      {% if states(sensor) != 'unknown' and states(sensor) != 'unavailable' %}
+      **Nearest:** {{ state_attr(sensor, 'headline') }} - {{ states(sensor) }} km {{ state_attr(sensor, 'direction') }}
+      {% endif %}

--- a/examples/cards/incident_summary_card.yaml
+++ b/examples/cards/incident_summary_card.yaml
@@ -1,0 +1,40 @@
+# Incident Summary Card for ABC Emergency
+#
+# Shows a quick overview of incident counts and nearest incident.
+# Replace "treehouse" with your zone name (lowercase, underscores for spaces)
+
+type: entities
+title: Emergency Summary
+show_header_toggle: false
+entities:
+  - entity: sensor.abc_emergency_treehouse_total_incidents
+    name: Total Incidents
+    icon: mdi:map-marker-multiple
+
+  - entity: sensor.abc_emergency_treehouse_nearby_incidents
+    name: Nearby Incidents
+    icon: mdi:map-marker-radius
+
+  - type: divider
+
+  - entity: sensor.abc_emergency_treehouse_bushfires
+    name: Bushfires
+    icon: mdi:fire
+
+  - entity: sensor.abc_emergency_treehouse_floods
+    name: Floods
+    icon: mdi:water
+
+  - entity: sensor.abc_emergency_treehouse_storms
+    name: Storms
+    icon: mdi:weather-lightning
+
+  - type: divider
+
+  - entity: sensor.abc_emergency_treehouse_nearest_incident
+    name: Nearest Distance (km)
+    icon: mdi:map-marker-distance
+
+  - entity: sensor.abc_emergency_treehouse_highest_alert_level
+    name: Highest Alert Level
+    icon: mdi:alert-decagram

--- a/examples/cards/map_card.yaml
+++ b/examples/cards/map_card.yaml
@@ -1,0 +1,18 @@
+# Simple Map Card for ABC Emergency
+#
+# Add this to any Lovelace dashboard to display emergency incidents on a map.
+# Replace "ABC Emergency (Treehouse)" with your config entry title.
+#
+# To find your source name:
+# 1. Go to Settings > Devices & Services > ABC Emergency
+# 2. The source name is your integration title (e.g., "ABC Emergency (Sydney)")
+
+type: map
+title: Emergency Incidents
+geo_location_sources:
+  - "ABC Emergency (Treehouse)"
+default_zoom: 10
+dark_mode: false
+theme_mode: auto
+hours_to_show: 24
+aspect_ratio: 16:9

--- a/examples/dashboard_emergency_map.yaml
+++ b/examples/dashboard_emergency_map.yaml
@@ -1,0 +1,177 @@
+# ABC Emergency Dashboard Example
+#
+# This dashboard displays emergency incidents on a map with alert indicators.
+#
+# USAGE:
+# 1. Copy this file to your Home Assistant config directory
+# 2. Add to configuration.yaml:
+#    lovelace:
+#      mode: storage
+#      dashboards:
+#        emergency:
+#          mode: yaml
+#          title: Emergency
+#          icon: mdi:alert
+#          show_in_sidebar: true
+#          filename: dashboard_emergency_map.yaml
+#
+# 3. Update entity names below to match your instance:
+#    - Replace "treehouse" with your zone name (lowercase, underscores for spaces)
+#    - Replace "ABC Emergency (Treehouse)" with your config entry title
+#
+# To find your geo_location_sources name:
+#   Go to Settings > Devices & Services > ABC Emergency
+#   The source name is your integration title (e.g., "ABC Emergency (Sydney)")
+#
+# NOTE: This requires the ABC Emergency integration to be installed and configured
+
+title: ABC Emergency
+views:
+  # View 1: Full-screen Map (PANEL view)
+  - title: Map
+    path: map
+    icon: mdi:map
+    type: panel
+    cards:
+      - type: map
+        geo_location_sources:
+          - "ABC Emergency (Treehouse)"
+        default_zoom: 9
+        hours_to_show: 24
+
+  # View 2: Dashboard Overview
+  - title: Overview
+    path: overview
+    icon: mdi:view-dashboard
+    cards:
+      # Embedded map card
+      - type: map
+        geo_location_sources:
+          - "ABC Emergency (Treehouse)"
+        default_zoom: 10
+        aspect_ratio: 16:9
+
+      # Alert Status tiles
+      - type: vertical-stack
+        cards:
+          - type: markdown
+            content: "## Alert Status"
+          - type: horizontal-stack
+            cards:
+              - type: tile
+                entity: binary_sensor.abc_emergency_treehouse_emergency_warning
+                name: Emergency
+                icon: mdi:alert-octagon
+                color: red
+              - type: tile
+                entity: binary_sensor.abc_emergency_treehouse_watch_and_act
+                name: Watch & Act
+                icon: mdi:alert
+                color: orange
+              - type: tile
+                entity: binary_sensor.abc_emergency_treehouse_advice
+                name: Advice
+                icon: mdi:information
+                color: amber
+
+      # Incident counts
+      - type: entities
+        title: Incident Summary
+        show_header_toggle: false
+        entities:
+          - entity: sensor.abc_emergency_treehouse_total_incidents
+            name: Total Incidents
+            icon: mdi:map-marker-multiple
+          - entity: sensor.abc_emergency_treehouse_nearby_incidents
+            name: Nearby Incidents
+            icon: mdi:map-marker-radius
+          - type: divider
+          - entity: sensor.abc_emergency_treehouse_bushfires
+            name: Bushfires
+            icon: mdi:fire
+          - entity: sensor.abc_emergency_treehouse_floods
+            name: Floods
+            icon: mdi:water
+          - entity: sensor.abc_emergency_treehouse_storms
+            name: Storms
+            icon: mdi:weather-lightning
+
+      # Nearest incident details
+      - type: markdown
+        title: Nearest Incident
+        content: |
+          {% set sensor = 'sensor.abc_emergency_treehouse_nearest_incident' %}
+          {% if states(sensor) != 'unknown' and states(sensor) != 'unavailable' and states(sensor) | float(0) > 0 %}
+          **{{ state_attr(sensor, 'headline') }}**
+
+          | Property | Value |
+          |----------|-------|
+          | Distance | {{ states(sensor) }} km |
+          | Direction | {{ state_attr(sensor, 'direction') }} |
+          | Type | {{ state_attr(sensor, 'event_type') }} |
+          | Alert Level | {{ state_attr(sensor, 'alert_level') }} |
+          {% else %}
+          No nearby incidents detected.
+          {% endif %}
+
+      # Highest alert level
+      - type: entity
+        entity: sensor.abc_emergency_treehouse_highest_alert_level
+        name: Highest Alert Level
+        icon: mdi:alert-decagram
+
+  # View 3: Bushfire Focus
+  - title: Bushfires
+    path: bushfires
+    icon: mdi:fire
+    cards:
+      - type: map
+        geo_location_sources:
+          - "ABC Emergency (Treehouse)"
+        default_zoom: 9
+        aspect_ratio: 16:9
+
+      - type: markdown
+        title: Active Bushfires
+        content: |
+          {% set sensor = 'sensor.abc_emergency_treehouse_bushfires' %}
+          {% set incidents = state_attr(sensor, 'incidents') or [] %}
+          {% if incidents | length > 0 %}
+          | Location | Alert | Distance | Direction |
+          |----------|-------|----------|-----------|
+          {% for incident in incidents[:15] %}
+          | {{ incident.headline }} | {{ incident.alert_level }} | {{ incident.distance_km | round(1) }} km | {{ incident.direction }} |
+          {% endfor %}
+          {% else %}
+          No active bushfire incidents in your area.
+          {% endif %}
+
+  # View 4: All Incidents List
+  - title: All Incidents
+    path: list
+    icon: mdi:format-list-bulleted
+    cards:
+      - type: entity
+        entity: sensor.abc_emergency_treehouse_total_incidents
+        name: Total Active Incidents
+
+      - type: markdown
+        title: Nearby Incidents
+        content: |
+          {% set sensor = 'sensor.abc_emergency_treehouse_nearby_incidents' %}
+          {% set incidents = state_attr(sensor, 'incidents') or [] %}
+          {% if incidents | length > 0 %}
+          {% for incident in incidents[:20] %}
+          ### {{ incident.headline }}
+          - **Type:** {{ incident.event_type }}
+          - **Alert:** {{ incident.alert_level }}
+          - **Distance:** {{ incident.distance_km | round(1) }} km {{ incident.direction }}
+          {% if incident.contains_point %}
+          - **You are inside this incident zone**
+          {% endif %}
+
+          ---
+          {% endfor %}
+          {% else %}
+          No incidents within your configured radius.
+          {% endif %}


### PR DESCRIPTION
## Summary

- Add Lovelace dashboard examples to help users quickly visualize ABC Emergency incidents on a map
- Include full dashboard YAML with 4 views (Map, Overview, Bushfires, All Incidents)
- Add individual card snippets for easy copy/paste into existing dashboards

## New Files

| File | Description |
|------|-------------|
| `examples/README.md` | Usage instructions and configuration guide |
| `examples/dashboard_emergency_map.yaml` | Complete dashboard with 4 views |
| `examples/cards/map_card.yaml` | Simple map card snippet |
| `examples/cards/alert_status_card.yaml` | Color-coded alert status tiles |
| `examples/cards/incident_summary_card.yaml` | Entity list showing incident counts |

## Dashboard Views

1. **Map** - Full-screen interactive map (panel type) showing all incidents
2. **Overview** - Dashboard with embedded map, alert tiles, and incident summary
3. **Bushfires** - Focused view with map and bushfire incident table
4. **All Incidents** - Scrollable list of nearby incidents with containment warnings

## Test Plan

- [x] Copy dashboard YAML to HA config and verify it loads
- [x] Verify map displays geo_location entities correctly
- [x] Verify entity names documentation is clear for customization

Fixes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)