### PR TITLE
feat(sensors): Add entity_ids attributes for map card integration

### DIFF
--- a/custom_components/abcemergency/strings.json
+++ b/custom_components/abcemergency/strings.json
@@ -113,6 +113,15 @@
       },
       "storms": {
         "name": "Storms"
+      },
+      "emergency_warnings": {
+        "name": "Emergency Warnings"
+      },
+      "watch_and_acts": {
+        "name": "Watch and Acts"
+      },
+      "advices": {
+        "name": "Advices"
       }
     },
     "binary_sensor": {

--- a/custom_components/abcemergency/translations/en.json
+++ b/custom_components/abcemergency/translations/en.json
@@ -113,6 +113,15 @@
       },
       "storms": {
         "name": "Storms"
+      },
+      "emergency_warnings": {
+        "name": "Emergency Warnings"
+      },
+      "watch_and_acts": {
+        "name": "Watch and Acts"
+      },
+      "advices": {
+        "name": "Advices"
       }
     },
     "binary_sensor": {


### PR DESCRIPTION
## Summary

Adds `entity_ids` and `containing_entity_ids` attributes to sensors and binary sensors to enable dynamic discovery of geo_location entities by map cards.

### Sensors
- Added `entity_ids` attribute to existing count sensors: `incidents_total`, `bushfires`, `floods`, `storms`, `incidents_nearby`
- Added 3 new alert-level sensors with `entity_ids`:
  - `emergency_warnings` - counts incidents at EMERGENCY level
  - `watch_and_acts` - counts incidents at WATCH_AND_ACT level  
  - `advices` - counts incidents at ADVICE level

### Binary Sensors
- Added `containing_entity_ids` attribute to containment sensors:
  - `inside_polygon`
  - `inside_emergency_warning`
  - `inside_watch_and_act`
  - `inside_advice`

### Entity ID Format
Entity IDs match the geo_location.py format: `geo_location.{slugify(instance_source_incident_id)}`

Example: `geo_location.abc_emergency_home_auremer_12345`

## Test Plan
- [x] All 500 tests passing
- [x] 100% code coverage maintained
- [x] Tests verify entity_ids attribute on all count sensors
- [x] Tests verify containing_entity_ids on containment binary sensors
- [x] Tests verify slugified entity ID format matches geo_location entities

Fixes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)