### PR TITLE
fix(geo_location): Set explicit entity_id to match sensor entity_ids format

### DIFF
--- a/custom_components/abcemergency/geo_location.py
+++ b/custom_components/abcemergency/geo_location.py
@@ -14,6 +14,7 @@ from homeassistant.const import UnitOfLength
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import slugify
 
 from .const import DOMAIN, GeoJSONMultiPolygon, GeoJSONPolygon
 from .coordinator import ABCEmergencyCoordinator
@@ -67,6 +68,9 @@ class ABCEmergencyGeolocationEvent(
         self._instance_source = instance_source
         self._attr_unique_id = f"{instance_source}_{incident.id}"
         self._attr_name = incident.headline
+        # Force predictable entity_id from unique incident ID to match sensor entity_ids
+        # attribute format and avoid collisions from duplicate headlines (#103)
+        self.entity_id = f"geo_location.{slugify(f'{instance_source}_{incident.id}')}"
 
     @property
     def source(self) -> str:


### PR DESCRIPTION
## Summary

- Fix entity ID mismatch between sensors and geo_location platform
- geo_location entities now use predictable entity_ids matching sensor format
- Eliminates collision risk from duplicate headlines

## Root Cause

Home Assistant generates geo_location entity IDs from the entity's `name` attribute (headline), not from `unique_id`. This caused a mismatch with the `entity_ids` attribute in sensors, which used the unique_id format:

| Platform | Generated ID |
|----------|--------------|
| Sensors (entity_ids attr) | `geo_location.abc_emergency_home_auremer_12345` |
| geo_location (from headline) | `geo_location.tunnel_firetrail_woy_woy` |

## Solution

Explicitly set `entity_id` in geo_location entities to match the sensor format:

```python
self.entity_id = f"geo_location.{slugify(f'{instance_source}_{incident.id}')}"
```

## Benefits

1. **Predictable entity IDs** - Always match what sensors report
2. **No collision risk** - Incident ID is unique (unlike headlines)
3. **Enables map card integration** - `geo_location_sources` feature now works
4. **Display name preserved** - `_attr_name` still uses headline for UI

## Test Plan

- [x] Added tests verifying entity_id matches sensor format
- [x] Added tests verifying no collisions with duplicate headlines
- [x] All 503 existing tests pass

Fixes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)