### PR TITLE
ci(pr-review): Update to official Claude Code GitHub Action

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -97,6 +97,7 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+      actions: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -104,15 +105,14 @@ jobs:
           fetch-depth: 0
 
       - name: Review with Claude
-        uses: grll/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
-          use_oauth: true
-          claude_access_token: ${{ secrets.CLAUDE_ACCESS_TOKEN }}
-          claude_refresh_token: ${{ secrets.CLAUDE_REFRESH_TOKEN }}
-          claude_expires_at: ${{ secrets.CLAUDE_EXPIRES_AT }}
-          secrets_admin_pat: ${{ secrets.SECRETS_ADMIN_PAT }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: 10
-          direct_prompt: |
+          claude_args: |
+            --max-turns 10
+            --allowedTools "Bash(gh pr:*),Bash(gh api:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*)"
+          prompt: |
             You are reviewing a Pull Request for the Home Assistant ABC Emergency integration.
 
             ## PR Details
@@ -208,5 +208,3 @@ jobs:
             - For this project, type safety and testing are non-negotiable
             - Be especially careful with changes to config_flow.py, coordinator.py, and API handling
             - This PR has already passed CI (tests, linting, type checking) so focus on design and logic
-
-          allowed_tools: "Bash(gh pr:*),Bash(gh api:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*)"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -107,6 +107,8 @@ jobs:
       - name: Review with Claude
         uses: anthropics/claude-code-action@v1
         with:
+          # Use OAuth token if available, otherwise fall back to API key
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: 10
           claude_args: |


### PR DESCRIPTION
## Summary

Fixes #119: Update PR review workflow to use official Claude Code GitHub Action.

The current workflow uses `grll/claude-code-action@beta` which is a third-party fork that is outdated and causing CI failures. This PR updates to the official `anthropics/claude-code-action@v1` maintained directly by Anthropic.

### Changes

| Before | After |
|--------|-------|
| `grll/claude-code-action@beta` | `anthropics/claude-code-action@v1` |
| OAuth tokens (`CLAUDE_ACCESS_TOKEN`, etc.) | API key (`ANTHROPIC_API_KEY`) |
| `direct_prompt` input | `prompt` input |
| `allowed_tools` input | `claude_args` with `--allowedTools` |

### Benefits

- **Official support** - Maintained by Anthropic, always up-to-date
- **Simpler authentication** - Single API key instead of OAuth token rotation
- **Better reliability** - No more "claude update" errors
- **Cleaner configuration** - Standard v1 API inputs

### Required Action

The repository owner needs to add `ANTHROPIC_API_KEY` to repository secrets:
1. Go to Settings > Secrets and variables > Actions
2. Add new secret: `ANTHROPIC_API_KEY` with your Anthropic API key

The old OAuth secrets (`CLAUDE_ACCESS_TOKEN`, `CLAUDE_REFRESH_TOKEN`, `CLAUDE_EXPIRES_AT`, `SECRETS_ADMIN_PAT`) can be removed after this is merged.

## Test Plan

- [x] YAML syntax validated
- [ ] CI workflow runs successfully (requires `ANTHROPIC_API_KEY` secret)
- [ ] AI Code Review job completes without "claude update" error

## References

- [Official Claude Code GitHub Action](https://github.com/anthropics/claude-code-action)
- [Official Documentation](https://code.claude.com/docs/en/github-actions)

---
Generated with [Claude Code](https://claude.ai/code)